### PR TITLE
Allure Path and environment reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Aries Mobile Test Harness<!-- omit in toc -->
 
   
@@ -107,8 +108,10 @@ If you have an open source wallet and would like to contribute and help others w
 If you do not wish to house your tests and page objects in the AMTH repo and would prefer to store theses in your own repo. You can add a requirement.txt file in a <wallet> folder in the page objects and test folders that contains something like, `mywallet-tests@git+https://github.com/myorg/mywallet-tests.git@main`
 When using the test harness from the AMTH repo, a `-w <mywallet>` option in the `.manage build` command  
 TODO: The manage script needs to be updated to support this option when someone desires it. 
+Another way to accomplish this is to actually make your repo a [submodule](https://gist.github.com/gitaarik/8735255) of the AMTH repo. This way,  one can use git commands to get the test repo and the AMTH repo together, but still live in different repos. 
 #### Option 3: Pull the AMTH into your environment
 If you have a private repo that holds your tests and page objects for your aries wallet, you can pull the AMTH from its repo to your environment or CI workflow. One way to do this is have a requirements.txt file somewhere in your repo containing `aries-mobile-test-harness@git+https://github.com/bcgov/aries-mobile-test-harness.git@main`, and gets used by tools in your repo to get the AMTH. Then copy your page objects and tests into the pulled test harness into a wallet folder for page objects and tests. Then build the test containers as stated at the beginning of the document with the `-w <mywallet>` option. 
+Another way to accomplish this is to actually make the AMTH repo a [submodule](https://gist.github.com/gitaarik/8735255) of your private repo. This way,  one can use git commands to get the test repo and the AMTH repo together, but still live in different repos. 
 
 ### Writting Page Objects for your Wallet
 Use the [page object model](https://www.selenium.dev/documentation/test_practices/encouraged/page_object_models/) to isolate app page changes from the test code. All appium calls to get and manipulate app elements should be in page objects, not the tests. Your page objects should live in the `aries-mobile-test-harness/aries-mobile-tests/pageobjects/<mywallet>/` folder. Your page objects may inherit from the `aries-mobile-test-harness/aries-mobile-tests/pageobjects/basepage.py` class. Follow the patterns laid out in the bifold wallet page objects in the AMTH repo.

--- a/aries-mobile-tests/README.md
+++ b/aries-mobile-tests/README.md
@@ -1,3 +1,4 @@
+
 # Aries Mobile Test Harness<!-- omit in toc -->
 
   
@@ -107,8 +108,10 @@ If you have an open source wallet and would like to contribute and help others w
 If you do not wish to house your tests and page objects in the AMTH repo and would prefer to store theses in your own repo. You can add a requirement.txt file in a <wallet> folder in the page objects and test folders that contains something like, `mywallet-tests@git+https://github.com/myorg/mywallet-tests.git@main`
 When using the test harness from the AMTH repo, a `-w <mywallet>` option in the `.manage build` command  
 TODO: The manage script needs to be updated to support this option when someone desires it. 
+Another way to accomplish this is to actually make your repo a [submodule](https://gist.github.com/gitaarik/8735255) of the AMTH repo. This way,  one can use git commands to get the test repo and the AMTH repo together, but still live in different repos. 
 #### Option 3: Pull the AMTH into your environment
 If you have a private repo that holds your tests and page objects for your aries wallet, you can pull the AMTH from its repo to your environment or CI workflow. One way to do this is have a requirements.txt file somewhere in your repo containing `aries-mobile-test-harness@git+https://github.com/bcgov/aries-mobile-test-harness.git@main`, and gets used by tools in your repo to get the AMTH. Then copy your page objects and tests into the pulled test harness into a wallet folder for page objects and tests. Then build the test containers as stated at the beginning of the document with the `-w <mywallet>` option. 
+Another way to accomplish this is to actually make the AMTH repo a [submodule](https://gist.github.com/gitaarik/8735255) of your private repo. This way,  one can use git commands to get the test repo and the AMTH repo together, but still live in different repos. 
 
 ### Writting Page Objects for your Wallet
 Use the [page object model](https://www.selenium.dev/documentation/test_practices/encouraged/page_object_models/) to isolate app page changes from the test code. All appium calls to get and manipulate app elements should be in page objects, not the tests. Your page objects should live in the `aries-mobile-test-harness/aries-mobile-tests/pageobjects/<mywallet>/` folder. Your page objects may inherit from the `aries-mobile-test-harness/aries-mobile-tests/pageobjects/basepage.py` class. Follow the patterns laid out in the bifold wallet page objects in the AMTH repo.

--- a/manage
+++ b/manage
@@ -513,7 +513,7 @@ startAgent() {
   fi
 }
 
-# TODO this should write some of the info in the appium/Sauce Labs config.json
+# Write some of the info in the appium/Sauce Labs config.json
 modifyConfigJson() {
   # if Platform is iOS, use the iOS.config.json
   if [[ "${DEVICE_PLATFORM}" == "iOS" ]]; then
@@ -533,8 +533,8 @@ modifyConfigJson() {
   contents="$(jq '.capabilities |= . + { "appium:platformName": "storage:filename=${APP_NAME}" }' ./aries-mobile-tests/config.json)" && \
   echo "${contents}" > config.json
 
-  export DEVICE=$(echo $contents | jq '(.capabilities |= . "appium:deviceName")[]')
-  export OS_VERSION=$(echo $contents | jq '(.capabilities |= . "appium:platformVersion")[]')
+  export DEVICE=$(echo $contents | jq -r '(.capabilities |= . "deviceName")[]')
+  export OS_VERSION=$(echo $contents | jq -r '(.capabilities |= . "platformVersion")[]')
 
   #docker cp ./aries-mobile-tests/config.json aries-mobile-test-harness:/aries-mobile-test-harness/aries-mobile-tests/config.json
 }
@@ -800,7 +800,7 @@ runTests() {
     fi
     if [[ "${REPORT}" = "allure" ]]; then
       echo "Executing tests with Allure Reports."
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/allure/allure-results:/aries-mobile-tests/allure/allure-results/" -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Issuer=http://0.0.0.0:9022/ -D Verifier=http://0.0.0.0:9032/
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/allure/allure-results:/aries-mobile-test-harness/aries-mobile-tests/allure/allure-results/" -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Issuer=http://0.0.0.0:9022/ -D Verifier=http://0.0.0.0:9032/
     else
       echo "Executing tests without Allure Reports."
       ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -D Issuer=http://0.0.0.0:9022/ -D Verifier=http://0.0.0.0:9032/


### PR DESCRIPTION
This PR fixes the wrong path specified for allure to save reports. 
Fixes some properties in environment.properties for allure. 

Also mentions the submodule approach for external repos to use AMTH.