### PR TITLE
11 Updated and working test scenarios

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/onboarding.feature
+++ b/aries-mobile-tests/features/bc_wallet/onboarding.feature
@@ -34,7 +34,7 @@ Feature: Onboarding
       | Share only what is neccessary screen   |
 
 
-  @T003-Onboarding @wip @AcceptanceTest
+  @T003-Onboarding @AcceptanceTest
   Scenario Outline: New User wants to go back to review previous reviewed onboarding material
     Given the new user has opened the app for the first time
     And the user is on the onboarding <screen>
@@ -48,7 +48,7 @@ Feature: Onboarding
       | Take control of your information screen | Share only what is neccessary screen   |
 
 
-  @T004-Onboarding @wip @FunctionalTest
+  @T004-Onboarding @FunctionalTest
   Scenario Outline: New User quits app mid review of onboarding material
     Given the new user has opened the app for the first time
     And the user is on the onboarding <screen>
@@ -66,6 +66,7 @@ Feature: Onboarding
 
   @T005-Onboarding @wip @FunctionalTest
   Scenario: New User wants to learn more about BC wallet during onboarding
-    Given The User has completed the Take control of your information screen
+    Given the new user has opened the app for the first time
+    And the user is on the "Take control of your information screen"
     When the user selects Learn more about BC Wallet
-    Then then they are brought to thier browser with more info about BC wallet
+    Then they are brought to thier browser with more info about BC wallet

--- a/aries-mobile-tests/features/steps/bc_wallet/onboarding.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/onboarding.py
@@ -29,6 +29,7 @@ def step_impl(context):
     assert context.thisOnboardingWelcomePage.on_this_page()
     # set a current onboarding page so the select Next step can be reused across these pages
     context.currentOnboardingPage = context.thisOnboardingWelcomePage
+    
 
 @when('the user selects Next')
 def step_impl(context):
@@ -71,7 +72,7 @@ def step_impl(context):
 def step_impl(context):
     assert context.thisTermsAndConditionsPage.on_this_page()
 
-
+@given('the user is on the "{screen}"')
 @given('the user is on the onboarding {screen}')
 def step_impl(context, screen):
     # Assume for now they start on the welcome screen
@@ -80,7 +81,7 @@ def step_impl(context, screen):
     if screen == "Welcome screen":
         # at the start of a test call the intial steps.
         context.execute_steps(f'''
-           Given the user is on the onboarding Welcome screen
+            Given the user is on the onboarding Welcome screen
         ''')
 
     elif screen == "Store your credentials securely screen":
@@ -143,3 +144,35 @@ def step_impl(context, previous_screen):
     elif previous_screen == "Share only what is neccessary screen":
         assert context.thisOnboardingShareNecessaryPage.on_this_page()
 
+
+@when('the user quits the app')
+def step_impl(context):
+    # close the app and reopen
+    context.driver.reset()
+
+
+@when('they reopen the app')
+def step_impl(context):
+    # app was opened in the driver.reset() call in the last step.
+    pass
+
+
+@then('they land on the Welcome screen')
+def step_impl(context):
+    context.execute_steps(f'''
+        Given the new user has opened the app for the first time
+        Given the user is on the onboarding Welcome screen
+    ''')
+
+
+@when('the user selects Learn more about BC Wallet')
+def step_impl(context):
+    context.thisOnboardingTakeControlPage.select_learn_more()
+
+
+@then('they are brought to thier browser with more info about BC wallet')
+def step_impl(context):
+    # TODO how to check for this?
+    print(context.driver.get().getContextHandles())
+    print(context.driver.getContext())
+    #raise NotImplementedError(u'STEP: Then they are brought to thier browser with more info about BC wallet')

--- a/aries-mobile-tests/pageobjects/basepage.py
+++ b/aries-mobile-tests/pageobjects/basepage.py
@@ -13,27 +13,31 @@ class BasePage(object):
     def set_device(self, context):
         self.driver = context.driver
         
-    def on_the_right_page(self, title):
-        # title_element = WebDriverWait(self.driver, 10).until(
-        #     EC.title_is(title))
-        # if title_element.name() == title:
-        #     return True
-        # else:
-        #     return False
+
+    def on_this_page(self, locator, timeout=10):
         
         # replace this sleep when there is an accessibility id on page titles.  
-        time.sleep(10)
-        return True
+        found_locator = False
+        i=0
+        while found_locator == False and i < timeout:
+            if locator in self.get_page_source():
+                found_locator = True
+            else:
+                found_locator = False
+            i = i + 1
+        return found_locator
+
 
     # Initialize and define the type of driver as WebDriver
     def __init__(self, driver):
         self.driver = driver
+        self.current_platform = driver.capabilities['platformName']
 
     # Locate by Accessibility id
-    def find_by_accessibility_id(self, locator):
+    def find_by_accessibility_id(self, locator, timeout=20):
         try:
 	        # The location of a single element gets the location of a single element
-            return WebDriverWait(self.driver, 20).until(
+            return WebDriverWait(self.driver, timeout).until(
                 EC.presence_of_element_located((MobileBy.ACCESSIBILITY_ID, locator))
             )
         except:
@@ -55,6 +59,9 @@ class BasePage(object):
             )
         except:
             raise Exception(f"Could not find element by element id Locator {locator}")
+
+    def get_page_source(self):
+        return self.driver.page_source
 
     # Positioning according to xpath
     def find_by_xpath(self, locator):

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboardingsharenecessary.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboardingsharenecessary.py
@@ -4,6 +4,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.onboardingtakecontrol import OnboardingTakeControlPage
+from pageobjects.bc_wallet.termsandconditions import TermsAndConditionsPage
 #from pageobjects.bc_wallet.onboardingstorecredssecurely import OnboardingStoreCredsSecurelyPage
 
 # These classes can inherit from a BasePage to do common setup and functions
@@ -14,42 +15,44 @@ class OnboardingShareNecessaryPage(BasePage):
     # TODO: If Ontario/BC or other wallets are closely alligned and only locators are different, 
     # we could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
     # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
-    title_locator = "Share only what is necessary"
+    on_this_page_text_locator = "Share only what is necessary"
     page_text_locator = "Page Text"
-    next_locator = "Next"
+    next_locator = {
+        "iOS": "nextButtonX",
+        "Android": "Next"
+    }
+    #next_locator = "Next"
+    #next_locator = "nextButton"
     skip_locator = "Skip"
     back_locator = "Back"
 
-    def on_this_page(self):
-        if self.on_the_right_page(self.title_locator):
-            return True
-        else:
-            return False
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator)
 
     def get_onboarding_text(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             pass
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_next(self):
-        if self.on_the_right_page(self.title_locator):
-            self.find_by_accessibility_id(self.next_locator).click()
+        if self.on_this_page():
+            self.find_by_accessibility_id(self.next_locator[self.current_platform]).click()
             return OnboardingTakeControlPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_back(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.back_locator).click()
             from pageobjects.bc_wallet.onboardingstorecredssecurely import OnboardingStoreCredsSecurelyPage
             return OnboardingStoreCredsSecurelyPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_skip(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.skip_locator).click()
-            return OnboardingTakeControlPage(self.driver)
+            return TermsAndConditionsPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboardingstorecredssecurely.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboardingstorecredssecurely.py
@@ -4,6 +4,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.onboardingsharenecessary import OnboardingShareNecessaryPage
+from pageobjects.bc_wallet.termsandconditions import TermsAndConditionsPage
 #from pageobjects.bc_wallet.onboardingwelcome import OnboardingWelcomePage
 
 # These classes can inherit from a BasePage to do common setup and functions
@@ -14,42 +15,43 @@ class OnboardingStoreCredsSecurelyPage(BasePage):
     # TODO: If Ontario/BC or other wallets are closely alligned and only locators are different, 
     # we could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
     # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
-    title_locator = "Share your credentials securely"
-    page_text_locator = "Page Text"
-    next_locator = "Next"
+    on_this_page_text_locator = "Store and secure credentials"
+    next_locator = {
+        "iOS": "nextButtonX",
+        "Android": "Next"
+    }
+    #next_locator = "Next"
+    #next_locator = "nextButton"
     skip_locator = "Skip"
     back_locator = "Back"
 
-    def on_this_page(self):
-        if self.on_the_right_page(self.title_locator):
-            return True
-        else:
-            return False
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator)
 
     def get_onboarding_text(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             pass
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_next(self):
-        if self.on_the_right_page(self.title_locator):
-            self.find_by_accessibility_id(self.next_locator).click()
+        if self.on_this_page():
+            self.find_by_accessibility_id(self.next_locator[self.current_platform]).click()
             return OnboardingShareNecessaryPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_back(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.back_locator).click()
             from pageobjects.bc_wallet.onboardingwelcome import OnboardingWelcomePage
             return OnboardingWelcomePage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_skip(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.skip_locator).click()
-            return OnboardingShareNecessaryPage(self.driver)
+            return TermsAndConditionsPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboardingtakecontrol.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboardingtakecontrol.py
@@ -14,43 +14,40 @@ class OnboardingTakeControlPage(BasePage):
     # TODO: If Ontario/BC or other wallets are closely alligned and only locators are different, 
     # we could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
     # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
-    title_locator = "Take control of your information"
+    on_this_page_text_locator = "Take control of your information"
     page_text_locator = "Page Text"
     learn_more_locator = "Learn more about BC Wallet"
     back_locator = "Back"
     get_started_locator = "Get Started"
 
-    def on_this_page(self):
-        if self.on_the_right_page(self.title_locator):
-            return True
-        else:
-            return False
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator)
 
     def get_onboarding_text(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             pass
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_learn_more(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.learn_more_locator).click()
             # TODO not sure what to do here if it opens a browser. return true for now.
             return True
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_back(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.back_locator).click()
             from pageobjects.bc_wallet.onboardingsharenecessary import OnboardingShareNecessaryPage
             return OnboardingShareNecessaryPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_get_started(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.get_started_locator).click()
             return TermsAndConditionsPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboardingwelcome.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboardingwelcome.py
@@ -4,6 +4,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.onboardingstorecredssecurely import OnboardingStoreCredsSecurelyPage
+from pageobjects.bc_wallet.termsandconditions import TermsAndConditionsPage
 
 # These classes can inherit from a BasePage to do common setup and functions
 class OnboardingWelcomePage(BasePage):
@@ -13,33 +14,35 @@ class OnboardingWelcomePage(BasePage):
     # TODO: If Ontario/BC or other wallets are closely alligned and only locators are different, 
     # we could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
     # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
-    title_locator = "Welcome"
-    page_text_locator = "Page Text"
-    next_locator = "Next"
+    on_this_page_text_locator = "Welcome"
+    # Getting around the iOS getbyAccessibilityID issue. testID seems to be replacing it.
+    next_locator = {
+        "iOS": "nextButtonX",
+        "Android": "Next"
+    }
+    #next_locator = "Next"
+    #next_locator = "nextButton"
     skip_locator = "Skip"
 
-    def on_this_page(self):
-        if self.on_the_right_page(self.title_locator):
-            return True
-        else:
-            return False
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator)   
 
     def get_onboarding_text(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             pass
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_next(self):
-        if self.on_the_right_page(self.title_locator):
-            self.find_by_accessibility_id(self.next_locator).click()
+        if self.on_this_page():
+            self.find_by_accessibility_id(self.next_locator[self.current_platform]).click()
             return OnboardingStoreCredsSecurelyPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
     def select_skip(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.skip_locator).click()
-            return OnboardingStoreCredsSecurelyPage(self.driver)
+            return TermsAndConditionsPage(self.driver)
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/termsandconditions.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/termsandconditions.py
@@ -12,29 +12,26 @@ class TermsAndConditionsPage(BasePage):
     # Locators
     # TODO: We could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
     # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
-    title_locator = "Terms of Service"
+    on_this_page_text_locator = "EULA"
     terms_and_conditions_accept_locator = "I Agree to the Terms of Service"
     continue_button_locator = "Submit"
     back_locator = "Back"
 
 
-    def on_this_page(self):
-        if self.on_the_right_page(self.title_locator):
-            return True
-        else:
-            return False
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator) 
 
     def select_accept(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.driver.swipe(500, 2000, 500, 100)
             self.find_by_accessibility_id(self.terms_and_conditions_accept_locator).click()
             return True
         else:
-            raise Exception(f"App not on the {self.title_locator} page")
+            raise Exception(f"App not on the {self.on_this_page_text_locator} page")
 
 
     def select_continue(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.continue_button_locator).click()
 
             # Maybe should check if it is checked or let the test call is_accept_checked()? 
@@ -45,7 +42,7 @@ class TermsAndConditionsPage(BasePage):
 
 
     def select_back(self):
-        if self.on_the_right_page(self.title_locator):
+        if self.on_this_page():
             self.find_by_accessibility_id(self.back_locator).click()
             # not sure what page to return here since they could of got here by skipping and they would return the the onboarding page
             # they selected skip on.


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR smooths out some issues running the same test code against Android and iOS. Namely iOS doesn't behave the same on the driver.reset(), and has to call driver.quit() after every scenario. This is causing the suite to take longer. There may be a fix for this, research is continuing. It also integrates a workaround with accessibility ids and testids being mistaken for each other in Appium. The locators are now dictionaries that pick a locator based on the platform being tested.  There are 10 passing tests scenarios out of 11 working. 

