### PR TITLE
workaround for iOS input fields

### DIFF
--- a/aries-mobile-tests/features/environment.py
+++ b/aries-mobile-tests/features/environment.py
@@ -72,7 +72,7 @@ def before_scenario(context, scenario):
 def after_scenario(context, scenario):
 
     device_cloud_service = os.environ['DEVICE_CLOUD']
-    if device_cloud_service == "SauceLabs":
+    if device_cloud_service == "SauceLabs" and hasattr(context, 'driver'):
 
         # Add the sauce Labs results and video url to the allure results
         # Link that requires a sauce labs account and login

--- a/aries-mobile-tests/features/steps/bc_wallet/secure.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/secure.py
@@ -29,11 +29,13 @@ def step_impl(context):
 @when('the User enters the first PIN as "{pin}"')
 def step_impl(context, pin):
     context.thisPINSetupPage.enter_pin(pin)
+    assert context.thisPINSetupPage.get_pin()
 
 
 @when('the User re-enters the PIN as "{pin}"')
 def step_impl(context, pin):
     context.thisPINSetupPage.enter_second_pin(pin)
+    assert context.thisPINSetupPage.get_second_pin()
 
 
 @when('the User selects Create PIN')

--- a/aries-mobile-tests/pageobjects/basepage.py
+++ b/aries-mobile-tests/pageobjects/basepage.py
@@ -4,6 +4,8 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 # BasePage to do common setup and functions
+
+
 class BasePage(object):
     """A base page object to do things common to all page objects"""
 
@@ -12,13 +14,12 @@ class BasePage(object):
 
     def set_device(self, context):
         self.driver = context.driver
-        
 
     def on_this_page(self, locator, timeout=10):
-        
-        # replace this sleep when there is an accessibility id on page titles.  
+
+        # replace this sleep when there is an accessibility id on page titles.
         found_locator = False
-        i=0
+        i = 0
         while found_locator == False and i < timeout:
             if locator in self.get_page_source():
                 found_locator = True
@@ -27,8 +28,8 @@ class BasePage(object):
             i = i + 1
         return found_locator
 
-
     # Initialize and define the type of driver as WebDriver
+
     def __init__(self, driver):
         self.driver = driver
         self.current_platform = driver.capabilities['platformName']
@@ -38,7 +39,8 @@ class BasePage(object):
         try:
 	        # The location of a single element gets the location of a single element
             return WebDriverWait(self.driver, timeout).until(
-                EC.presence_of_element_located((MobileBy.ACCESSIBILITY_ID, locator))
+                EC.presence_of_element_located(
+                    (MobileBy.ACCESSIBILITY_ID, locator))
             )
         except:
             try:
@@ -48,17 +50,33 @@ class BasePage(object):
                 # )
                 return self.driver.find_element_by_name(locator)
             except:
-	            raise Exception(f"Could not find element by Accessibility id or Name Locator {locator}")
+                raise Exception(
+                    f"Could not find element by Accessibility id or Name Locator {locator}")
+
+    # Locate multiple elements by Accessibility id.
+    # this is a workaround for when iOS may have translated the labels down into text and input fields.
+    # we shouldn't be calling this very much, and when we have to, we should log an issue with the wallet for unique accessibilituy IDs
+    def find_multiple_by_accessibility_id(self, locator, timeout=20):
+        try:
+	        # The location of a single element gets the location of a single element
+            return WebDriverWait(self.driver, timeout).until(
+                EC.presence_of_all_elements_located(
+                    (MobileBy.ACCESSIBILITY_ID, locator))
+            )
+        except:
+            raise Exception(
+                f"Could not find elements by Accessibility id {locator}")
 
     # Locate by id
     def find_by_element_id(self, locator):
         try:
 	        # The location of a single element gets the location of a single element
             return WebDriverWait(self.driver, 10).until(
-                EC.presence_of_element_located((MobileBy.ID , locator))
+                EC.presence_of_element_located((MobileBy.ID, locator))
             )
         except:
-            raise Exception(f"Could not find element by element id Locator {locator}")
+            raise Exception(
+                f"Could not find element by element id Locator {locator}")
 
     def get_page_source(self):
         return self.driver.page_source

--- a/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
@@ -19,15 +19,35 @@ class PINSetupPage(BasePage):
 
     def enter_pin(self, pin):
         if self.on_this_page():
-            self.find_by_accessibility_id(self.first_pin_locator).send_keys(pin)
+            if self.current_platform == "iOS":
+                self.find_multiple_by_accessibility_id(self.first_pin_locator)[2].send_keys(pin)
+            else:
+                #self.find_by_accessibility_id(self.second_pin_locator).click()
+                self.find_by_accessibility_id(self.first_pin_locator).send_keys(pin)
             return True
+        else:
+            raise Exception(f"App not on the {self.title_locator} page")
+
+    def get_pin(self):
+        if self.on_this_page():
+            return self.find_by_accessibility_id(self.first_pin_locator).text
         else:
             raise Exception(f"App not on the {self.title_locator} page")
 
     def enter_second_pin(self, pin):
         if self.on_this_page():
-            self.find_by_accessibility_id(self.second_pin_locator).send_keys(pin)
+            if self.current_platform == "iOS":
+                self.find_multiple_by_accessibility_id(self.second_pin_locator)[2].send_keys(pin)
+            else:
+                #self.find_by_accessibility_id(self.second_pin_locator).click()
+                self.find_by_accessibility_id(self.second_pin_locator).send_keys(pin)
             return True
+        else:
+            raise Exception(f"App not on the {self.title_locator} page")
+
+    def get_second_pin(self):
+        if self.on_this_page():
+            return self.find_by_accessibility_id(self.second_pin_locator).text
         else:
             raise Exception(f"App not on the {self.title_locator} page")
 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR implements a workaround for a problem in the BC wallet PIN Creation screen with iOS where input fields may have multiple elements with the same accessibility id (label). We now do a get elements (plural) and pick the one for the input before we do a sendKeys(). This is a workaround and hopefully we can get a build where the accessibility id is unique. However, it may be an idiosyncrasy with iOS.

For AMTH in general this PR contains an update to BasePage with a new method to get the multiple elements by accessibility id. fyi @dipeshnb