### PR TITLE
added URL support for issuer and verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,6 @@ Build and run the tests
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device_cloud_username> -k <device_cloud_access_key> -p Android -a app-release.apk -i acapy-main -v acapy-main -t @Connect
 ```
 
-The alternative is to run runTest.sh to do all of it for you granted you created a .env file at the root folder.
-You must complete the following key/values that will be sourced at runtime.
-```
-DEVICE_CLOUD_USERNAME=???
-DEVICE_CLOUD_ACCESS_KEY=???
-APP_APK_LOCATION=/home/{LinuxIsBest}/Documents/{AppName}.apk
-APP_NAME=???
-```
   
 
 ## Contents<!-- omit in toc -->
@@ -132,13 +124,23 @@ The AMTH `./manage` script in the repo root folder is used to manage running bui
 
 `./manage` is a bash script, so you must be in a bash compatible shell to run the AMTH. You must also have an operational docker installation and git installed.  As well, the current AMTH requires access to a running Indy network. You can also pass in environment variables for the LEDGER_URL, GENESIS_URL or GENESIS_FILE to use a remote network. For example `LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io`
 
-Before running tests, you must build the Issuer, Verifier and harness docker images. Use `./manage build -w <walletname> -i <issuer> -v <verifier>` to build the docker images the agents, and the test harness itself.  Currently only `acapy-main` is supported for both issuer and verifier. The plan is to allow for other domain specific agents that will be communicating with the wallet under test to be built or pointed to with these options. 
 
-To run the tests, use the `./manage run...` sub-command. The `run` command requires defining what agents will be used for issuer `-i` and verifier `-v`. To review the the other options for the run command use the `./manage help` command. Essentially these other options are used to contstruct a test config for appium to tell the device cloud what platforms, devices, and operating systems to use on the devices. 
+Before running tests, must build the test harness docker image.`./manage build -w <walletname>` 
+You can build an Aca-py Issuer, Verifier. Use `./manage build -w <walletname> -i <issuer> -v <verifier>` to build the docker images the agents. Currently only `acapy-main` is supported for both issuer and verifier. Note these agents do not have a controller, you would be communicating with their admin APIs. Your tests become the controller handling web hooks, etc.  If you are testing your wallet with other agents as the issuer and verifier, see the `./manage run` command below on how to pass a URL to  point to your issuer or verifier controller/agent. 
+  
+
+To run the tests, use the `./manage run...` sub-command. The `run` command requires defining what agents will be used for issuer `-i` and verifier `-v`. To review the the other options for the run command use the `./manage help` command. Essentially these other options are used to contstruct a test config for appium to tell the device cloud what platforms, devices, and operating systems to use on the devices.
+
+The `-i issuer` and `-v verifier` in the `run` command can also take a URL to your controller/agent. One recommendation is to use [Aries Agent Test Harness agents](https://github.com/hyperledger/aries-agent-test-harness/#using-aath-agents-as-services) and backchannel controllers to speed up mobile wallet test development. 
 
 An example of a fully composed run command that tests a BC Bifold Android app that is located in the Sauce Labs device cloud is as follows;
+
 ```bash
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device-cloud-username> -k <device-cloud-access-key> -p Android -a app-release.apk -i acapy-main -v acapy-main -t @Connect
+```
+Here is an example of a run command what tests the BC wallet iOS app and uses some locally running Aries Agent Test Harness agents as issuer and verifier;
+```bash
+LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device-cloud-username> -k <device-cloud-access-key> -p iOS -a AriesBifold-114.ipa -i http://0.0.0.0:9020 -v http://0.0.0.0:9030 -t @bc_wallet -t @T001-Connect
 ```
 
 NOTE: you will need your own Sauce Labs username and access key for this command to work. 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,17 @@ An example of a fully composed run command that tests a BC Bifold Android app th
 ```bash
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device-cloud-username> -k <device-cloud-access-key> -p Android -a app-release.apk -i acapy-main -v acapy-main -t @Connect
 ```
-Here is an example of a run command what tests the BC wallet iOS app and uses some locally running Aries Agent Test Harness agents as issuer and verifier;
+Here is a full example of a run command what tests the BC wallet iOS app and uses some locally running Aries Agent Test Harness agents as issuer and verifier;
+Clone, build and run AATH agents
 ```bash
+git clone https://github.com/hyperledger/aries-agent-test-harness
+cd aries-agent-test-harness
+./manage build -a acapy-main
+LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io TAILS_SERVER_URL_CONFIG=https://tails.vonx.io AGENT_CONFIG_FILE=/aries-backchannels/acapy/auto_issuer_config.yaml ./manage start -a acapy-main -b acapy-main -n
+```
+Run BC Wallet Tests in AMTH with those AATH agents
+```bash
+./manage build -w bc_wallet
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device-cloud-username> -k <device-cloud-access-key> -p iOS -a AriesBifold-114.ipa -i http://0.0.0.0:9020 -v http://0.0.0.0:9030 -t @bc_wallet -t @T001-Connect
 ```
 

--- a/aries-mobile-tests/README.md
+++ b/aries-mobile-tests/README.md
@@ -124,13 +124,23 @@ The AMTH `./manage` script in the repo root folder is used to manage running bui
 
 `./manage` is a bash script, so you must be in a bash compatible shell to run the AMTH. You must also have an operational docker installation and git installed.  As well, the current AMTH requires access to a running Indy network. You can also pass in environment variables for the LEDGER_URL, GENESIS_URL or GENESIS_FILE to use a remote network. For example `LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io`
 
-Before running tests, you must build the Issuer, Verifier and harness docker images. Use `./manage build -w <walletname> -i <issuer> -v <verifier>` to build the docker images the agents, and the test harness itself.  Currently only `acapy-main` is supported for both issuer and verifier. The plan is to allow for other domain specific agents that will be communicating with the wallet under test to be built or pointed to with these options. 
 
-To run the tests, use the `./manage run...` sub-command. The `run` command requires defining what agents will be used for issuer `-i` and verifier `-v`. To review the the other options for the run command use the `./manage help` command. Essentially these other options are used to contstruct a test config for appium to tell the device cloud what platforms, devices, and operating systems to use on the devices. 
+Before running tests, must build the test harness docker image.`./manage build -w <walletname>` 
+You can build an Aca-py Issuer, Verifier. Use `./manage build -w <walletname> -i <issuer> -v <verifier>` to build the docker images the agents. Currently only `acapy-main` is supported for both issuer and verifier. Note these agents do not have a controller, you would be communicating with their admin APIs. Your tests become the controller handling web hooks, etc.  If you are testing your wallet with other agents as the issuer and verifier, see the `./manage run` command below on how to pass a URL to  point to your issuer or verifier controller/agent. 
+  
+
+To run the tests, use the `./manage run...` sub-command. The `run` command requires defining what agents will be used for issuer `-i` and verifier `-v`. To review the the other options for the run command use the `./manage help` command. Essentially these other options are used to contstruct a test config for appium to tell the device cloud what platforms, devices, and operating systems to use on the devices.
+
+The `-i issuer` and `-v verifier` in the `run` command can also take a URL to your controller/agent. One recommendation is to use [Aries Agent Test Harness agents](https://github.com/hyperledger/aries-agent-test-harness/#using-aath-agents-as-services) and backchannel controllers to speed up mobile wallet test development. 
 
 An example of a fully composed run command that tests a BC Bifold Android app that is located in the Sauce Labs device cloud is as follows;
+
 ```bash
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device-cloud-username> -k <device-cloud-access-key> -p Android -a app-release.apk -i acapy-main -v acapy-main -t @Connect
+```
+Here is an example of a run command what tests the BC wallet iOS app and uses some locally running Aries Agent Test Harness agents as issuer and verifier;
+```bash
+LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device-cloud-username> -k <device-cloud-access-key> -p iOS -a AriesBifold-114.ipa -i http://0.0.0.0:9020 -v http://0.0.0.0:9030 -t @bc_wallet -t @T001-Connect
 ```
 
 NOTE: you will need your own Sauce Labs username and access key for this command to work. 

--- a/aries-mobile-tests/agent_test_utils.py
+++ b/aries-mobile-tests/agent_test_utils.py
@@ -19,6 +19,7 @@ def get_qr_code_from_invitation(invitation_json):
     #img = qr.make_image(fill_color="red", back_color="#23dda0")
     img = qr.make_image()
     img.save('./qrcode_test.png')
+    qr.print_ascii(invert=True)
 
     with io.BytesIO() as output:
         img.save(output, format="PNG")

--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -1,10 +1,21 @@
-@Connect @bc_wallet
-Feature: Connect to an Issuer/Scan QR Code
+# https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/76
+@Connect @bc_wallet @Story_76
+Feature: Connect to an Issuer/Scan QR Code for Credential
 
-   @T001-Connect @wip
-   Scenario: Connect to an Issuer based on a QR code
-      Given the terms of service has been accepted
-      And a PIN has been set up
-      When the wallet user scans the QR code sent by the issuer
-      And accepts the connection
-      Then there is a connection between Issuer and wallet user
+
+@T001-Connect @wip @critical @AcceptanceTest
+Scenario: Scan QR code to recieve a credential offer
+   Given the User has completed on-boarding
+   And the User has accepted the Terms and Conditions
+   And a PIN has been set up with "369369"
+   When the Holder scans the QR code sent by the issuer
+   And the Holder is taken to the Connecting Screen/modal
+   And the Connecting completes successfully
+   Then there is a connection between Issuer and Holder
+
+@T002-Connect @wip @normal @AcceptanceTest
+Scenario: Scan QR code to recieve a credential offer but exits scanning
+
+@T003-Connect @wip @minor @FunctionalTest
+Scenario: Scan QR code with flash on to recieve a credential offer
+

--- a/aries-mobile-tests/pageobjects/bc_wallet/connecting.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/connecting.py
@@ -1,0 +1,25 @@
+import time
+from appium.webdriver.common.mobileby import MobileBy
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from pageobjects.basepage import BasePage
+
+
+# These classes can inherit from a BasePage to do common setup and functions
+class ConnectingPage(BasePage):
+    """Connecting to an Agent Screen page object"""
+
+    # Locators
+    on_this_page_text_locator = "Just a moment while we make a secure connection"
+    back_to_home_locator = "Go back to home"
+
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator)   
+
+    def select_go_back_to_home(self):
+        if self.on_this_page():
+            self.find_by_accessibility_id(self.back_to_home_locator).click()
+            from pageobjects.bc_wallet.home import HomePage
+            return HomePage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/settings.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/settings.py
@@ -5,22 +5,17 @@ from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.contacts import ContactsPage
 from pageobjects.bc_wallet.connecting import ConnectingPage
-from pageobjects.bc_wallet.settings import SettingsPage
 
 
-class HomePage(BasePage):
+class SettingsPage(BasePage):
     """Home page object"""
 
     # Locators
-    on_this_page_text_locator = "Welcome"
-    home_locator = "Home"
-    scan_locator = "Scan"
-    credentials_locator = "Credentials"
-    settings_locator = "Settings"
+    on_this_page_text_locator = "App Preferences"
+    back_locator = "Go Back"
     contacts_locator = "Contacts"
 
     def on_this_page(self):     
-        print(self.driver.page_source)
         return super().on_this_page(self.on_this_page_text_locator) 
 
     def select_notification(self, context):

--- a/manage
+++ b/manage
@@ -93,6 +93,7 @@ usage () {
 
     Examples:
     $0 build -w bifold -i acapy-main -v acapy-main  - Build the Aries Mobile Test harness to test bifold, use acapy-main as the issuer and the verifier.
+    $0 build -w bc_wallet - Use the BC Wallet files in the test container, issuer and verifier are managed outside the test harness and will be pointed to in the run command.
 
   rebuild [ -w wallet ] [ -i/v agent ]*
     Same as build, but adds the --no-cache option to force building from scratch
@@ -112,16 +113,18 @@ usage () {
         "-p iOS" or "-p Android"
       Use -a to specify the app name or id of the app loaded into the device cloud service
       Use -i to specify the issuer to use in the tests
-        Currenty supporting acapy-main
+        Currenty supporting acapy-main or a URL to another agent controller
       Use -v to specify the verifier to use in the tests
-        Currenty supporting acapy-main
+        Currenty supporting acapy-main or a URL to another agent controller
       Use the -r option to output to allure
         (allure is the only supported option)
 LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 
 
     Examples:
     $0 run -d SauceLabs -u oauth-my.username-35de1 -k 4dba5e68-16c1-4632-b44e-4a543601610d -p Android -a app-release.apk -i acapy-main -v acapy-main -t @Connect
-      - Run all tests tagged with Connect on SauceLabs with the app-release.apk app on the android platform. Use acapy-main as the basis for the issuer and verifier. 
+      - Run all tests tagged with Connect on SauceLabs with the app-release.apk app on the Android platform. Use acapy-main as the basis for the issuer and verifier. 
+    $0 run -d SauceLabs -u oauth-my.username-35de1 -k 4dba5e68-16c1-4632-b44e-4a543601610d -p iOS -a AriesBCWallet.ipa -i http://0.0.0.0:9020 -v http://0.0.0.0:9030 -t @Connect
+      - Run all tests tagged with Connect on SauceLabs with the AriesBCWallet.ipa app on the iOS platform. Use some externaly mamaged and stared agents for the issuer and verifier. 
 
   tags - Get a list of the tags on the features tests
 
@@ -229,7 +232,9 @@ function initEnv() {
 buildImages() {
   args=${@}
 
-  echo "Agents to build: Issuer:${ISSUER_AGENT}, Verifier:${VERIFIER_AGENT}"
+  if [[ ${ISSUER_AGENT} ]] || [[ ${VERIFIER_AGENT} ]]; then
+    echo "Agents to build: Issuer:${ISSUER_AGENT}, Verifier:${VERIFIER_AGENT}"
+  fi
 
   for agent in ${BUILD_AGENTS}; do
     export AGENT_FOLDER=$(dirname "$(find agents -name *.${agent})" )
@@ -747,20 +752,30 @@ startHarness(){
   dockerhost_url_templates
 
   #export ISSUER_AGENT=${ISSUER_AGENT:-${ISSUER}-agent}
-  export ISSUER_AGENT=${ISSUER}-agent
+  #export ISSUER_AGENT=${ISSUER}-agent
   #export VERIFIER_AGENT=${VERIFIER_AGENT:-$VERIFIER}-agent}
-  export VERIFIER_AGENT=${VERIFIER}-agent
+  #export VERIFIER_AGENT=${VERIFIER}-agent
   # export AIP_CONFIG=${AIP_CONFIG:-10}
 
   export PROJECT_ID=${PROJECT_ID:-general}
 
   # start agents or ...
-  startAgent Issuer issuer_agent "$ISSUER_AGENT" "9020-9029" 9020 9021 "20" "$ISSUER"
-  startAgent Verifier verifier_agent "$VERIFIER_AGENT" "9030-9039" 9030 9031 "20" "$VERIFIER"
+  if [[ "$ISSUER_AGENT" != *"http"* ]]; then 
+    export ISSUER_AGENT=${ISSUER}-agent
+    startAgent Issuer issuer_agent "$ISSUER_AGENT" "9020-9029" 9020 9021 "20" "$ISSUER"
+  fi
+  if [[ "$VERIFIER_AGENT" != *"http"* ]]; then
+    export VERIFIER_AGENT=${VERIFIER}-agent
+    startAgent Verifier verifier_agent "$VERIFIER_AGENT" "9030-9039" 9030 9031 "20" "$VERIFIER"
+  fi
 
   echo
-  waitForAgent Issuer 9020
-  waitForAgent Verifier 9030
+  if [[ "$ISSUER_AGENT" != *"http"* ]]; then
+    waitForAgent Issuer 9020
+  fi
+  if [[ "$VERIFIER_AGENT" != *"http"* ]]; then
+    waitForAgent Verifier 9030
+  fi
 
   echo
   # config.json file handling
@@ -798,6 +813,18 @@ runTests() {
   export BEHAVE_INI_TMP="$(pwd)/behave.ini.tmp"
   cp ${BEHAVE_INI} ${BEHAVE_INI_TMP}
 
+  # Set Issuer and Verifier URL
+  if [[ "$ISSUER_AGENT" == *"http"* ]]; then
+    issuerURL=$ISSUER_AGENT
+  else
+    issuerURL="http://0.0.0.0:9022/"
+  fi
+  if [[ "$VERIFIER_AGENT" == *"http"* ]]; then
+    verifierURL=$VERIFIER_AGENT
+  else
+    verifierURL="http://0.0.0.0:9032/"
+  fi
+
   echo "Running with Device Cloud Service ${DEVICE_CLOUD}"
   if [[ "${DEVICE_CLOUD}" = "SauceLabs" ]]; then
     # if Region is not set default to us-west-1
@@ -806,10 +833,10 @@ runTests() {
     fi
     if [[ "${REPORT}" = "allure" ]]; then
       echo "Executing tests with Allure Reports."
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/allure/allure-results:/aries-mobile-test-harness/aries-mobile-tests/allure/allure-results/" -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e DEVICE_CLOUD=${DEVICE_CLOUD} -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Issuer=http://0.0.0.0:9022/ -D Verifier=http://0.0.0.0:9032/
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/allure/allure-results:/aries-mobile-test-harness/aries-mobile-tests/allure/allure-results/" -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e DEVICE_CLOUD=${DEVICE_CLOUD} -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -f allure_behave.formatter:AllureFormatter -o ./allure/allure-results -f progress -D Issuer=${issuerURL} -D Verifier=${verifierURL}
     else
       echo "Executing tests without Allure Reports."
-      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e DEVICE_CLOUD=${DEVICE_CLOUD} -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -D Issuer=http://0.0.0.0:9022/ -D Verifier=http://0.0.0.0:9032/
+      ${terminalEmu} docker run ${INTERACTIVE} --rm --network="host" -v ${BEHAVE_INI_TMP}:/aries-mobile-tests/behave.ini -v "$(pwd)/aries-mobile-tests/config.json:/aries-mobile-test-harness/aries-mobile-tests/config.json" -e DEVICE_CLOUD=${DEVICE_CLOUD} -e SAUCE_USERNAME=${DEVICE_CLOUD_USERNAME} -e SAUCE_ACCESS_KEY=${DEVICE_CLOUD_ACCESS_KEY} -e SL_REGION=${SL_REGION} aries-mobile-test-harness -k ${runArgs} -D Issuer=${issuerURL} -D Verifier=${verifierURL}
     fi
   #else # place holder for other device cloud services like BrowserStack, etc.
   fi
@@ -986,8 +1013,9 @@ if [[ "${COMMAND}" == "run" || "${COMMAND}" == "start" || "${COMMAND}" == "test"
 
   if [[ "${COMMAND}" == "run" || "${COMMAND}" == "test" ]]; then
     for agent in ${ISSUER_AGENT} ${VERIFIER_AGENT}; do
-        if [[ $(isAgent $agent) == false ]] ; then
-            echo All agents Issuer and Verifier must be set to one of: ${VALID_AGENTS}.
+        if [[ $(isAgent $agent) == false ]] && [[ "$agent" != *"http"* ]]; then 
+            echo All agents Issuer and Verifier must be set to one of: ${VALID_AGENTS}
+            echo or a URL to your agent controller.
             echo Use \"${0} help\" to get more information.
             exit 1
         fi
@@ -1026,15 +1054,17 @@ if [[ "${COMMAND}" == "build" || "${COMMAND}" == "rebuild" ]]; then
   shift $((OPTIND-1))
 
   # Determine what agents to build. Only build once if Issuer and Verifier are the same. 
-  export BUILD_AGENTS="${BUILD_AGENTS} ${ISSUER_AGENT}"
-  if [ "$ISSUER_AGENT" != "$VERIFIER_AGENT" ]; then
+  if [[ "$ISSUER_AGENT" ]]; then 
+    export BUILD_AGENTS="${BUILD_AGENTS} ${ISSUER_AGENT}"
+  fi
+  if [[ "$VERIFIER_AGENT" ]] || [[ "$VERIFIER_AGENT" != "$ISSUER_AGENT" ]]; then
     export BUILD_AGENTS="${BUILD_AGENTS} ${VERIFIER_AGENT}"
   fi
 
-  # TODO Check here to see if the wallet passed in is in the VALID_WALLETS list, if not, exit.
-  if [ "$BUILD_AGENTS" == "" ]; then
-     BUILD_AGENTS=${VALID_AGENTS}
-  fi
+    # TODO Check here to see if the wallet passed in is in the VALID_WALLETS list, if not, exit.
+    # if [ "$BUILD_AGENTS" == "" ]; then
+    #   BUILD_AGENTS=${VALID_AGENTS}
+    # fi
   # echo "Wallet entered is not a valid wallet. See aries-mobile-test-harness/aries-mobile-tests/pageobjects/ for wallets"
   # echo "If your wallet is not in that location, add pageobjects for your wallet and place it in a directory of your wallet name."
   # exit 1


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR adds support for a URL as the issuer and verifier on the run command to point your mobile tests to an external agent/controller. If you don't have an agent/controller in these roles for your wallet, the recommendation is to use the [Aries Agent Test Harness agents](https://github.com/hyperledger/aries-agent-test-harness/#using-aath-agents-as-services) in your tests. fyi @dipeshnb