### PR TITLE
Externalized proof data and documentation

### DIFF
--- a/EXTERNALIZED_TEST_DATA.md
+++ b/EXTERNALIZED_TEST_DATA.md
@@ -2,11 +2,10 @@
 
 ## Contents<!-- omit in toc -->
 
--  [Default Test Credentials and Proofs](#default-test-credentials-and-the-need-for-more)
--  [Defining Tests in Feature Files w/ Externalized Credential Data](#defining-tests-in-feature-files-with-externalized-credential-info)
--  [Credential Type Definitions](#credential-type-definitions)
--  [Credential Data](#credential-data)
--  [Proof Requests](#proof-requests)
+-  [Default Test Credentials](#default-test-credentials)
+-  [Defining Tests in Feature Files w/ Externalized Credential Data](#defining-tests-in-feature-files-with-externalized-credential-data)
+-  [Defining Tests in Feature Files w/ Externalized Proof Data](#defining-tests-in-feature-files-with-externalized-proof-data)
+-  [Summary](#summary)
 
 ## Default Test Credentials
 Each Issuer and Verifier agent interface implemented in AMTH should have a default credential and a default proof that are created and used when no parameters are are passed to the interface to send a credential offer or send a proof request. This is the case with the current AATH issuer and verfier interfaces. In this case we may have the need to change the type of credential and the type of proof used, to do this we can externalize this test data into json data files. This is what this document will explain.

--- a/EXTERNALIZED_TEST_DATA.md
+++ b/EXTERNALIZED_TEST_DATA.md
@@ -1,0 +1,157 @@
+# Externalizing Credential and Proof Test Data<!-- omit in toc -->
+
+## Contents<!-- omit in toc -->
+
+-  [Default Test Credentials and Proofs](#default-test-credentials-and-the-need-for-more)
+-  [Defining Tests in Feature Files w/ Externalized Credential Data](#defining-tests-in-feature-files-with-externalized-credential-info)
+-  [Credential Type Definitions](#credential-type-definitions)
+-  [Credential Data](#credential-data)
+-  [Proof Requests](#proof-requests)
+
+## Default Test Credentials
+Each Issuer and Verifier agent interface implemented in AMTH should have a default credential and a default proof that are created and used when no parameters are are passed to the interface to send a credential offer or send a proof request. This is the case with the current AATH issuer and verfier interfaces. In this case we may have the need to change the type of credential and the type of proof used, to do this we can externalize this test data into json data files. This is what this document will explain.
+
+Other interfaces to other issuers or verfiers may have only one type of credential or proof it uses, so in this case the default is the only one used. You may wish to populate the credential with test data, this is simply accomplished with the normal approach of using data tables in the feature file Scenarios. 
+
+The use of externalized data is illustrated in the BC Wallet tests that are included in the AMTH repo. You can look at these test cases to dig into examples of this externalization of credential and proof test data; `@T002.1-CredentialOffer` `@T002.1-Proof`
+ 
+## Defining Tests in Feature Files with Externalized Credential Data
+Tests that have externalized input data for credentials and proofs use Example Data Tables to feed the test with input data. This input data is contained in json files located in `/aries-mobile-test-harness/mobile-test-harness/features/data` for general usage, and in `/aries-mobile-test-harness/mobile-test-harness/features/data/<wallet>` for specific usage. 
+
+```gherkin
+   @T002.1-CredentialOffer @critical @AcceptanceTest
+   Scenario Outline: Holder accepts the credential offer recieved
+      Given the User has completed on-boarding
+      And the User has accepted the Terms and Conditions
+      And a PIN has been set up with "369369"
+      And a connection has been successfully made
+      And the user has a credential offer for <credential>
+      When they select Accept
+      And the holder is informed that their credential is on the way with an indication of loading
+      And once the credential arrives they are informed that the Credential is added to your wallet
+      And they select Done
+      Then they are brought to the list of credentials
+      And the credential accepted is at the top of the list
+         | issuer_agent_type | credential_name |
+         | AATHIssuer        | Photo Id        |
+
+      Examples:
+         | credential         |
+         | cred_data_photo_id |
+```
+
+In the credential offer example above the data for the credential offered is in a json file called `/aries-mobile-test-harness/mobile-test-harness/features/data/cred_data_photo_id.json`. It contains the following;
+```json
+{
+   "schema_name": "photo_id",
+   "schema_version": "1.0.0",
+   "attributes": [
+      {
+         "name": "name",
+         "value": "Betty Naroff"
+      },
+      {
+         "name": "civic_address",
+         "value": "159 Cedar Street, Sudbury, ON"
+      },
+      ...
+      },
+      {
+         "name": "photo",
+         "value": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWAAAADICAIAAABZO6wsAAAAAXNSR0IArs4c6QAAAARnQ..."
+      },
+      {
+         "name": "issue_date",
+         "value": "2022-04-04T13:32:55.455Z"
+      },
+      {
+         "name": "expiry_date",
+         "value": "2027-04-04T13:32:55.455Z"
+      }
+   ]
+}
+```
+
+These are the attributes and values that will be offered to the holder in this test case. Notice that this data holds a `schema_name` and `schema_version`. These fields are used to get the credential type information from a corrisponding json file called `schema_photo_id.json`. This file is used in the AATH agents to check if the schema exists, create a schema and credential defininition. The contents of this json file are;
+```json
+{
+   "schema_name":"photo_id",
+   "schema_version":"1.0.0",
+   "attributes":[
+      "name",
+      "civic_address",
+      "city",
+      "province",
+      "country",
+      "postal_code",
+      "birth_dateint",
+      "photo",
+      "issue_date",
+      "expiry_date"
+   ]
+}
+```
+Follow these patterns and json file structure/schema to create your own credetials to use with AATH issuer and verifier agents or your own agents. 
+
+
+## Defining Tests in Feature Files with Externalized Proof Data
+Proof Requests case follow the same pattern as the Credential Offer case above. This proof request data file is a proof request for the credential above.
+
+```gherkin
+   @T002.1-Proof @critical @AcceptanceTest
+   Scenario Outline: Holder accepts the proof request
+      Given the User has completed on-boarding
+      And the User has accepted the Terms and Conditions
+      And a PIN has been set up with "369369"
+      And a connection has been successfully made
+      And the holder has a credential of <credential>
+         | issuer_agent_type | credential_name |
+         | AATHIssuer        | Photo Id        |
+      And the user has a proof request for <proof>
+      When they select Share
+      And the holder is informed that they are sending information securely
+      And once the proof is verified they are informed of such
+      And they select Done on the verfified information
+      Then they are brought Home
+
+      Examples:
+         | credential         | proof          |
+         | cred_data_photo_id | proof_photo_id |
+```
+The addition of the proof in this sceanrio adds a `proof_photo_id` in the table data that corrisponds to the `/aries-mobile-test-harness/mobile-test-harness/features/data/proof_photo_id.json`. It contains the contexts of the proof request that gets passed to the AATH Verifier Agent.
+```json
+{
+   "requested_attributes": {
+      "photo_attrs": {
+         "names": [
+               "photo"
+            ],
+         "restrictions": [
+               {
+                  "schema_name": "photo_id",
+                  "schema_version": "1.0.0"
+               }
+         ]
+      }
+   },
+   "requested_predicates": {
+      "age": {
+         "name": "birth_dateint",
+         "p_type": ">",
+         "p_value": 19420116,
+         "restrictions": [
+               {
+                  "schema_name": "photo_id",
+                  "schema_version": "1.0.0"
+               }
+         ]
+      }
+   },
+   "version": "0.1.0"
+}
+```
+
+## Summary
+With the constructs above is should be very easy to add new tests based off of new credentials and proofs, along with running existing tests with new credentials and proofs. Essentially, once the json files are created, opening a credential offer or proof feature file, adding a row to the examples data table, one should have a new running test scenario with those new credentials.
+
+Keep in mind that this currently works with the AATH issuer and verifier agents. As we move forward these same data files could be used with other issuers or verifiers, but it is likely that those agents will have thier own inbred credentials and proofs. Alternate forms of test data marshalling may need to be considered with other agents.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Upload an app to the device cloud
 Build and run the tests
 
 ```bash
-./manage build -w bifold -i acapy-main -v acapy-main
+./manage build -w bc_wallet
 
-LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device_cloud_username> -k <device_cloud_access_key> -p Android -a app-release.apk -i acapy-main -v acapy-main -t @Connect
+LEDGER_URL_CONFIG=http://test.bcovrin.vonx.io REGION=us-west-1 ./manage run -d SauceLabs -u <device_cloud_username> -k <device_cloud_access_key> -p Android -a app-release.apk -i "AATH;http://0.0.0.0:9020" -v "AATH;http://0.0.0.0:9030" -t @bc_wallet -t @T002.1-Proof
 ```
 
   
@@ -95,14 +95,19 @@ AMTH test scripts are written in the [Gherkin](https://behave.readthedocs.io/en/
 
 ## Implementing Tests for Your Wallet
 
-When implementing tests, the first step is to create a feature file. This feature file should contain your wallet name in the file name. For example, `aries-mobile-test-harness/aries-mobile-tests/features/bifold_connect.feature`
-The corresponding steps file for the feature should be put in `aries-mobile-test-harness/aries-mobile-tests/features/steps/bifold/connect.py`
-Step files should always call page objects to manipulate the app. 
-On the `build` command only feature files with the `<mywallet>_` prefix is copied into the test harness container. Also only the steps in the `/steps/<mywallet>/` folder is copied into the container.
-TODO: The manage script needs to be updated to add imports for the wallet name passed in with the `-w` build option into the `aries-mobile-test-harness/aries-mobile-tests/features/steps/all_steps.py` file. For example for bifold we add `from steps.bifold.connect import *`  to the `all_steps.py` file.
+When implementing tests, the first step is to create a feature file. This feature file should located in a separate wallet folder inside the features folder. For example, `aries-mobile-test-harness/aries-mobile-tests/features/bc_wallet/connect.feature`
+
+The corresponding steps file for the feature should be put in `aries-mobile-test-harness/aries-mobile-tests/features/steps/bc_wallet/connect.py`
+
+Step files should always call page objects to manipulate the app. Steps should never make appium calls directly. Make this the soul purpose of the page objects. Page objects should be located in their own folder for the specific wallet. For example, `aries-mobile-test-harness/aries-mobile-tests/page_objects/bc_wallet/connecting.py`
+
+If you use and specific external test data for your wallet testing, they should be located in `aries-mobile-test-harness/aries-mobile-tests/features/data/bc_wallet/`. If you are working directly in the AMTH repo for your wallet tests, and you have test data files that can be used across wallets, you should put that test data in `aries-mobile-test-harness/aries-mobile-tests/features/data/`. Click through for more information on [externalizing your credential and proof test data](https://github.com/hyperledger/aries-mobile-test-harness/blob/main/EXTERNALIZED_TEST_DATA.md).
+
+On the `build` command only feature files, page_objects, and data within the corresponding wallet named folders are copied into the test harness container. The wallet steps in the `/steps/<mywallet>/` folder are imported into an all_steps.py file so Behave will only see the step implementations in that file for your wallet.
+
 
 ### Deciding Where to Store a Wallets Tests and Page Objects
-#### Option 1: House the wallets tests in the AMTH repo
+#### Option 1: House the wallet tests in the AMTH repo
 If you have an open source wallet and would like to contribute and help others with your tests as examples, please feel free to store your tests and page objects in the [AMTH Repo](https://github.com/hyperledger/aries-mobile-test-harness).
 #### Option 2: Tell the AMTH where to get your tests
 If you do not wish to house your tests and page objects in the AMTH repo and would prefer to store theses in your own repo. You can add a requirement.txt file in a <wallet> folder in the page objects and test folders that contains something like, `mywallet-tests@git+https://github.com/myorg/mywallet-tests.git@main`

--- a/aries-mobile-tests/agent_factory/aath/aath_verifier_agent_interface.py
+++ b/aries-mobile-tests/agent_factory/aath/aath_verifier_agent_interface.py
@@ -28,7 +28,6 @@ class AATHVerifierAgentInterface(VerifierAgentInterface, AATHAgentInterface):
         else:
             topic = "proof"
 
-        # check for a schema template already loaded in the context. If it is, it was loaded from an external Schema, so use it.
         if request_for_proof:
             pass
             # if context.non_revoked_timeframe:

--- a/aries-mobile-tests/features/bc_wallet/credential_offer.feature
+++ b/aries-mobile-tests/features/bc_wallet/credential_offer.feature
@@ -39,7 +39,7 @@ Feature: Offer a Credential
          | issuer_agent_type | credential_name |
          | AATHIssuer        | Test Schema     |
 
-   @T002.1-CredentialOffer @wip @critical @AcceptanceTest @Story_79 @Story_82
+   @T002.1-CredentialOffer @critical @AcceptanceTest @Story_79 @Story_82
    Scenario Outline: Holder accepts the credential offer recieved
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -42,6 +42,28 @@ Feature: Proof
       And they select Done on the verfified information
       Then they are brought Home
 
+
+   @T002.1-Proof @critical @AcceptanceTest @Story_29
+   Scenario Outline: Holder accepts the proof request
+      Given the User has completed on-boarding
+      And the User has accepted the Terms and Conditions
+      And a PIN has been set up with "369369"
+      And a connection has been successfully made
+      And the holder has a credential of <credential>
+         | issuer_agent_type | credential_name |
+         | AATHIssuer        | Photo Id        |
+      And the user has a proof request for <proof>
+      When they select Share
+      And the holder is informed that they are sending information securely
+      And once the proof is verified they are informed of such
+      And they select Done on the verfified information
+      Then they are brought Home
+
+      Examples:
+         | credential         | proof          |
+         | cred_data_photo_id | proof_photo_id |
+
+
 #Connectionless
 
 #Revokable

--- a/aries-mobile-tests/features/data/proof_photo_id.json
+++ b/aries-mobile-tests/features/data/proof_photo_id.json
@@ -1,0 +1,29 @@
+{
+   "requested_attributes": {
+      "photo_attrs": {
+         "names": [
+               "photo"
+            ],
+         "restrictions": [
+               {
+                  "schema_name": "photo_id",
+                  "schema_version": "1.0.0"
+               }
+         ]
+      }
+   },
+   "requested_predicates": {
+      "age": {
+         "name": "birth_dateint",
+         "p_type": ">",
+         "p_value": 19420116,
+         "restrictions": [
+               {
+                  "schema_name": "photo_id",
+                  "schema_version": "1.0.0"
+               }
+         ]
+      }
+   },
+   "version": "0.1.0"
+}

--- a/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
@@ -86,7 +86,7 @@ def step_impl(context):
     ''')
 
 
-@given('the user has a credential offer for {credential}')
+@given('the user has a credential offer of {credential}')
 def step_impl(context, credential):
     context.execute_steps(f'''
         When the Holder receives a credential offer of {credential}
@@ -97,7 +97,7 @@ def step_impl(context, credential):
 
 @when('they select Accept')
 def step_impl(context):
-    context.thisCredentialOnTheWayPage = context.thisCredentialOfferPage.select_accept()
+    context.thisCredentialOnTheWayPage = context.thisCredentialOfferPage.select_accept(scroll=True)
 
 
 @when('the holder is informed that their credential is on the way with an indication of loading')

--- a/aries-mobile-tests/features/steps/bc_wallet/terms.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/terms.py
@@ -31,6 +31,15 @@ def step_impl(context):
             Then they can select Get started
         ''')
 
+
+@given('the User has skipped on-boarding')
+def step_impl(context):
+    context.execute_steps(f'''
+            Given the new user has opened the app for the first time
+            Given the user is on the onboarding Welcome screen
+            When the user selects Skip
+        ''')
+
 @given('the User is on the Terms and Conditions screen')
 def step_impl(context):
     context.execute_steps(f'''

--- a/aries-mobile-tests/pageobjects/basepage.py
+++ b/aries-mobile-tests/pageobjects/basepage.py
@@ -106,3 +106,22 @@ class BasePage(object):
     def find_by_classname(self, *locator):
         # classname location is rarely used. It is generally used when id location and xpath location cannot be used. What you get is a list. You can use the list to query the location of a specific element
         return self.driver.find_elements_by_class_name(*locator)
+
+    def scroll_to_element(self, locator, incremental_scroll_amount=500, timeout=20, find_by=MobileBy.ACCESSIBILITY_ID):
+        element = None
+        i = 0
+        while element == None and i < timeout:
+            try: 
+                if find_by == MobileBy.ACCESSIBILITY_ID:
+                    element = self.find_by_accessibility_id(locator)
+                else:
+                    element = self.find_by_element_id(locator)
+                self.driver.swipe(500, incremental_scroll_amount, 500, 100)
+            except:
+                # not found try again
+                i = i + 1
+        if element:
+            return True
+        else:
+            return False
+

--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
@@ -24,8 +24,11 @@ class CredentialOfferPage(BasePage):
         #print(self.driver.page_source)
         return super().on_this_page(self.on_this_page_text_locator)
 
-    def select_accept(self):
+    def select_accept(self, scroll=False):
         if self.on_this_page():
+            # if the credential has a lot of attributes it could need to scroll
+            if scroll == True:
+                self.scroll_to_element(self.accept_locator, 1500)
             self.find_by_accessibility_id(self.accept_locator).click()
             return CredentialOnTheWayPage(self.driver)
         else:

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboardingsharenecessary.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboardingsharenecessary.py
@@ -21,7 +21,8 @@ class OnboardingShareNecessaryPage(BasePage):
     back_locator = "com.ariesbifold:id/Back"
     next_locator = "com.ariesbifold:id/Next"
 
-    def on_this_page(self):     
+    def on_this_page(self): 
+        #print(self.driver.page_source)      
         return super().on_this_page(self.on_this_page_text_locator)
 
     def get_onboarding_text(self):


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR adds support for externalized proof test data. It has a working example of that proof data in the BC Wallet test `@T002.1-Proof`. 

Usage of the externalized test data has also been documented. 