### PR TITLE
Fixed send cred issue in AATH interface

### DIFF
--- a/aries-mobile-tests/agent_factory/aath/aath_issuer_agent_interface.py
+++ b/aries-mobile-tests/agent_factory/aath/aath_issuer_agent_interface.py
@@ -108,7 +108,10 @@ class AATHIssuerAgentInterface(IssuerAgentInterface, AATHAgentInterface):
 
         # if data is none, use a default cred
         # if data is not none then use it as the cred
-        cred_data = credential_offer["attributes"] or self.DEFAULT_CREDENTIAL_ATTR_TEMPLATE.copy()
+        if credential_offer:
+            cred_data = credential_offer["attributes"] 
+        else:
+            cred_data = self.DEFAULT_CREDENTIAL_ATTR_TEMPLATE.copy()
 
         cred_offer = {
             "cred_def_id": self._credential_definition["credential_definition_id"],


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Send Credential on the Issuer Interface for AATH agents was giving an error on the default credential with the new externalized data code added. Now fixed. 