### PR TITLE
added printing page source on failure option

### DIFF
--- a/aries-mobile-tests/agent_test_utils.py
+++ b/aries-mobile-tests/agent_test_utils.py
@@ -6,7 +6,7 @@ import io
 from qrcode import QRCode
 from PIL import Image
 
-def get_qr_code_from_invitation(invitation_json):
+def get_qr_code_from_invitation(invitation_json, print_qr_code=False, save_qr_code=False):
     # message_bytes = json.dumps(invitation).encode("ascii")
     # base64_bytes = base64.b64encode(message_bytes)
     # base64_message = base64_bytes.decode("ascii")
@@ -18,8 +18,10 @@ def get_qr_code_from_invitation(invitation_json):
     qr.make()
     #img = qr.make_image(fill_color="red", back_color="#23dda0")
     img = qr.make_image()
-    img.save('./qrcode_test.png')
-    qr.print_ascii(invert=True)
+    if save_qr_code:
+        img.save('./qrcode_test.png')
+    if print_qr_code:
+        qr.print_ascii(invert=True)
 
     with io.BytesIO() as output:
         img.save(output, format="PNG")

--- a/aries-mobile-tests/behave.ini
+++ b/aries-mobile-tests/behave.ini
@@ -6,9 +6,14 @@
 #junit_directory = ./reports
 format=json.pretty
 no_skipped=true
+stderr_capture=false
+stdout_capture=false
 #logging_level = INFO
 
 [behave.userdata]
+print_page_source_on_failure=False
+print_qr_code_on_creation=False
+save_qr_code_on_creation=False
 # these should be set dynamically, when running under Docker
 #Acme = http://localhost:8020
 #Bob  = http://localhost:8070

--- a/aries-mobile-tests/features/environment.py
+++ b/aries-mobile-tests/features/environment.py
@@ -66,6 +66,9 @@ def before_feature(context, feature):
     aif = AgentInterfaceFactory()
     context.issuer = aif.create_issuer_agent_interface(issuer_type, issuer_endpoint)
     context.verifier = aif.create_verifier_agent_interface(verifier_type, verifier_endpoint)
+    context.print_page_source_on_failure = eval(context.config.userdata['print_page_source_on_failure'])
+    context.print_qr_code_on_creation = eval(context.config.userdata['print_qr_code_on_creation'])
+    context.save_qr_code_on_creation = eval(context.config.userdata['save_qr_code_on_creation'])
 
 
 
@@ -88,6 +91,10 @@ def before_scenario(context, scenario):
 
 
 def after_scenario(context, scenario):
+
+    if scenario.status == Status.failed and context.print_page_source_on_failure:
+        print(context.driver.page_source)
+
 
     device_cloud_service = os.environ['DEVICE_CLOUD']
     if device_cloud_service == "SauceLabs" and hasattr(context, 'driver'):

--- a/aries-mobile-tests/features/steps/bifold/connect.py
+++ b/aries-mobile-tests/features/steps/bifold/connect.py
@@ -39,7 +39,7 @@ def step_impl(context):
     (resp_status, resp_text) = agent_controller_POST(context.issuer_url, "connections", operation="create-invitation")
     assert resp_status == 200, f'resp_status {resp_status} is not 200; {resp_text}'
     invitation_json = json.loads(resp_text)
-    qrimage = get_qr_code_from_invitation(invitation_json)
+    qrimage = get_qr_code_from_invitation(invitation_json, context.print_qr_code_on_creation, context.save_qr_code_on_creation)
 
     context.thisHomePage.inject_connection_invite_qr_code(qrimage)
     # Do we need to load the scan page after image injection? probably not. 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

behave.ini now has a `print_page_source_on_failure` option. If this is True, when the scenario fails, it will print a dump of the screen elements in the app. Good for debugging locator changes.