### PR TITLE
fixed biometrics call

### DIFF
--- a/aries-mobile-tests/config.json
+++ b/aries-mobile-tests/config.json
@@ -1,13 +1,13 @@
 {
   "capabilities": {
-    "project": "BC Wallet",
-    "build": "build-1",
-    "platformName": "iOS",
-    "app": "storage:filename=AriesBifold-76.ipa",
-    "deviceName": "iPhone.*",
-    "platformVersion": "15.3",
-    "sessionCreationRetry": "3",
-    "sauceLabsImageInjectionEnabled": true,
-    "autoGrantPermissions": true
+    "appPackage": "ca.bc.gov.BCWallet",
+    "appium:appActivity": "ca.bc.gov.BCWallet.MainActivity",
+    "platformName": "Android",
+    "app": "/Users/Shel/Projects/BC.gov/apps/bifold-bc/AriesBifold-209.apk",
+    "deviceName": "Android Accelerated Oreo",
+    "udid": "emulator-5554",
+    "automationName": "UiAutomator2",
+    "autoGrantPermissions": true,
+    "fullReset": false
   }
 }

--- a/aries-mobile-tests/device_service_handler/device_service_handler_interface.py
+++ b/aries-mobile-tests/device_service_handler/device_service_handler_interface.py
@@ -48,7 +48,7 @@ class DeviceServiceHandlerInterface(ABC):
         """pass the qrcode image to the device in a way that allows for the device to scan it when the camera opens"""
 
     @abstractmethod
-    def biometrics_authenticate(self, bool):
+    def biometrics_authenticate(self, authenticate:bool):
         """authenticate when biometrics, ie fingerprint or faceid, true is success, false is fail biometrics"""
 
     @abstractmethod

--- a/aries-mobile-tests/device_service_handler/local_android_handler.py
+++ b/aries-mobile-tests/device_service_handler/local_android_handler.py
@@ -42,9 +42,12 @@ class LocalAndroidHandler(DeviceServiceHandlerInterface):
         shutil.copy(
             "qrcode.png", f"{android_home}/emulator/resources/qrcode.png")
 
-    def biometrics_authenticate(self, bool):
+    def biometrics_authenticate(self, authenticate:bool):
         """authenticate when biometrics, ie fingerprint or faceid, true is success, false is fail biometrics"""
-        self._driver.finger_print(1)
+        if authenticate:
+            self._driver.finger_print(1)
+        else:
+            self._driver.finger_print(0)
 
     def supports_test_result(self) -> bool:
         """return true if the device service supports setting a pass or fail flag in thier platform"""

--- a/aries-mobile-tests/device_service_handler/sauce_labs_handler.py
+++ b/aries-mobile-tests/device_service_handler/sauce_labs_handler.py
@@ -73,9 +73,12 @@ class SauceLabsHandler(DeviceServiceHandlerInterface):
         """pass the qrcode image to the device in a way that allows for the device to scan it when the camera opens"""
         self._driver.execute_script(f"sauce:inject-image={image}")
 
-    def biometrics_authenticate(self, bool):
+    def biometrics_authenticate(self, authenticate:bool):
         """authenticate when biometrics, ie fingerprint or faceid, true is success, false is fail biometrics"""
-        self._driver.execute_script('sauce:biometrics-authenticate=true')
+        if authenticate:
+            self._driver.execute_script('sauce:biometrics-authenticate=true')
+        else:
+            self._driver.execute_script('sauce:biometrics-authenticate=false')
 
     def supports_test_result(self) -> bool:
         """return true if the device service supports setting a pass or fail flag in thier platform"""

--- a/aries-mobile-tests/features/environment.py
+++ b/aries-mobile-tests/features/environment.py
@@ -60,8 +60,7 @@ def before_scenario(context, scenario):
     # TODO fullReset may have to be moved to the config files, if dev starts to use the Test Harness they may
     # want tests with previous state maintained. 
     extra_desired_capabilities = {
-        'name': scenario.name,
-        'fullReset':True
+        'name': scenario.name
     }
     device_service_handler.set_desired_capabilities(extra_desired_capabilities)
 

--- a/aries-mobile-tests/local_android_config.json
+++ b/aries-mobile-tests/local_android_config.json
@@ -7,6 +7,7 @@
     "deviceName": "Android Accelerated Oreo",
     "udid": "emulator-5554",
     "automationName": "UiAutomator2",
-    "autoGrantPermissions": true
+    "autoGrantPermissions": true,
+    "fullReset": true
   }
 }

--- a/aries-mobile-tests/local_ios_config.json
+++ b/aries-mobile-tests/local_ios_config.json
@@ -8,7 +8,8 @@
         "platformVersion":"15.3",
         "sessionCreationRetry" : "3",
         "sauceLabsImageInjectionEnabled": true,
-        "autoAcceptAlerts": true
+        "autoAcceptAlerts": true,
+        "fullReset": true
     }
 }
 
@@ -35,5 +36,6 @@
     "appium:xcodeOrgId": "L796QSLV3E",
     "appium:xcodeSigningId": "Apple Distribution: Her Majesty the Queen in right of the Province of British Columbia (L796QSLV3E)",
     "appium:updatedWDABundleId": "ca.bc.gov.*",
-    "appium:automationName": "XCUITest"
+    "appium:automationName": "XCUITest",
+    "fullReset": false
   }

--- a/aries-mobile-tests/pageobjects/bc_wallet/are_you_sure_decline_proof_request.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/are_you_sure_decline_proof_request.py
@@ -11,8 +11,8 @@ class AreYouSureDeclineProofRequestPage(BasePage):
 
     # Locators
     on_this_page_text_locator = "Are you sure you want to decline this proof request"
-    no_go_back_locator = (MobileBy.ID, "com.ariesbifold:id/Share")
-    confirm_locator = (MobileBy.ID, "com.ariesbifold:id/Decline")
+    no_go_back_locator = (MobileBy.ID, "com.ariesbifold:id/AbortDeclineButton")
+    confirm_locator = (MobileBy.ID, "com.ariesbifold:id/ConfirmDeclineButton")
 
 
     def on_this_page(self):

--- a/aries-mobile-tests/pageobjects/bc_wallet/proof_request.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/proof_request.py
@@ -31,8 +31,11 @@ class ProofRequestPage(BasePage):
 
     def select_share(self):
         if self.on_this_page():
-            self.scroll_to_element(self.share_aid_locator[1])
-            self.find_by(self.share_locator).click()
+            try:
+                self.find_by(self.share_locator).click()
+            except:
+                self.scroll_to_element(self.share_aid_locator[1])
+                self.find_by(self.share_locator).click()
             return SendingInformationSecurelyPage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/sl_android_config.json
+++ b/aries-mobile-tests/sl_android_config.json
@@ -8,6 +8,7 @@
         "platformVersion":"11",
         "sessionCreationRetry" : "3",
         "sauceLabsImageInjectionEnabled": true,
-        "autoGrantPermissions": true
+        "autoGrantPermissions": true,
+        "fullReset": true
     }
 }

--- a/aries-mobile-tests/sl_ios_config.json
+++ b/aries-mobile-tests/sl_ios_config.json
@@ -8,6 +8,7 @@
         "platformVersion":"15.3",
         "sessionCreationRetry" : "3",
         "sauceLabsImageInjectionEnabled": true,
-        "autoAcceptAlerts": true
+        "autoAcceptAlerts": true,
+        "fullReset": true
     }
 }


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

The biometrics authentication calls were ignoring the boolean passed into the handler. Fixed that. 

Found a couple of changed test IDs in the BC wallet revocation page objects. And also fixed an isolated scrolling issue on android for a BC Wallet test. 

Moved fullReset from a hard coded value in the capabilities to the json files. This will allow keeping the app installed in its post test state which may be useful for debugging. 