### PR TITLE
Fixed bcw init timeout and try pipeline without tunnel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,12 +49,13 @@ jobs:
         with:
           USE_NGROK: ""
 
-      - name: run-sauce-connect-tunnel
-        uses: saucelabs/sauce-connect-action@v2
-        with:
-          username: ${{ secrets.SAUCE_USERNAME }}
-          accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
+      # - name: run-sauce-connect-tunnel
+      #   uses: saucelabs/sauce-connect-action@v2
+      #   with:
+      #     username: ${{ secrets.SAUCE_USERNAME }}
+      #     accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+      #     directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
+
       #    tunnelIdentifier: github-action-tunnel
       #    region: us-west-1
 
@@ -94,13 +95,13 @@ jobs:
           REPORT_PROJECT: ${{ matrix.report-project }}
         continue-on-error: true
 
-      - name: Shutdown Sauce Connect Tunnel
-        run: |
-          docker ps \
-          --format '{{.ID}} {{.Image}}' | \
-          grep saucelabs/sauce-connect | \
-          awk '{print $1}' | \
-          xargs docker stop
+      # - name: Shutdown Sauce Connect Tunnel
+      #   run: |
+      #     docker ps \
+      #     --format '{{.ID}} {{.Image}}' | \
+      #     grep saucelabs/sauce-connect | \
+      #     awk '{print $1}' | \
+      #     xargs docker stop
 
       - name: Run AMTH Connectionless Tests
         uses: ./.github/workflows/run-test-harness

--- a/aries-mobile-tests/pageobjects/bc_wallet/initialization.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/initialization.py
@@ -28,13 +28,13 @@ class InitializationPage(BasePage):
         loading = True
         loop_timeout = time.time() + timeout
         while loading == True:
+            if time.time() > loop_timeout:
+                raise Exception(f"App Initialization taking longer than expected. Timing out at {timeout} seconds.")
             try:
                 self.find_by(self.loading_locator, timeout=5)
             except Exception as e:
                 if "Could not find element by" in str(e):
                     loading = False
-                    if time.time() > loop_timeout:
-                        raise Exception(f"App Initialization taking longer than expected. Timeing out at {timeout} seconds.")
                 else:
                     raise e
         return HomePage(self.driver)


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

The BC Wallet test timeout check for initialization of the wallet was in the wrong location and would never get checked. 

Also removes the Sauce Tunnel from the test pipeline to see if the android runs will work better on initialization. iOS has no issue. 