### PR TITLE
Re-enable the sauce tunnel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,12 +49,12 @@ jobs:
         with:
           USE_NGROK: ""
 
-      # - name: run-sauce-connect-tunnel
-      #   uses: saucelabs/sauce-connect-action@v2
-      #   with:
-      #     username: ${{ secrets.SAUCE_USERNAME }}
-      #     accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-      #     directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
+      - name: run-sauce-connect-tunnel
+        uses: saucelabs/sauce-connect-action@v2
+        with:
+          username: ${{ secrets.SAUCE_USERNAME }}
+          accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+          directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
 
       #    tunnelIdentifier: github-action-tunnel
       #    region: us-west-1
@@ -95,13 +95,13 @@ jobs:
           REPORT_PROJECT: ${{ matrix.report-project }}
         continue-on-error: true
 
-      # - name: Shutdown Sauce Connect Tunnel
-      #   run: |
-      #     docker ps \
-      #     --format '{{.ID}} {{.Image}}' | \
-      #     grep saucelabs/sauce-connect | \
-      #     awk '{print $1}' | \
-      #     xargs docker stop
+      - name: Shutdown Sauce Connect Tunnel
+        run: |
+          docker ps \
+          --format '{{.ID}} {{.Image}}' | \
+          grep saucelabs/sauce-connect | \
+          awk '{print $1}' | \
+          xargs docker stop
 
       - name: Run AMTH Connectionless Tests
         uses: ./.github/workflows/run-test-harness


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Connecting to agents didn't work in the pipeline without the Sauce Connect Tunnel. Re-enabling it. 