### PR TITLE
Feature/offline handling

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/offline_handling.feature
+++ b/aries-mobile-tests/features/bc_wallet/offline_handling.feature
@@ -1,0 +1,136 @@
+# https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/386
+# Stories Below are not finalized yet
+# https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/414
+# https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/413
+# https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/392
+@OfflineHandling @bc_wallet
+Feature: Wallet Offline Handling
+  In order to have a seemless experience in the wallet and make any corrections to my device that could hinder my wallet experience
+  As user of BC Wallet
+  I want to to know when I loose internet connectivity
+
+
+  @T001-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @AndroidOnly
+  Scenario: Holder opens BC Wallet while mobile phone is offline
+    Given the Holder has setup thier Wallet
+    And they have closed the app
+    And the mobile phone does not have an internet connection
+    When the holder opens BC Wallet
+    And authenticates with thier PIN as "369369"
+    And initialization ends (failing silently)
+    Then they are presented with a dismissible "no internet connection" toast notification
+
+
+  @T002-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @AndroidOnly
+  Scenario Outline: BC Wallet does not detect internet connection while in use
+    Given the Holder has setup thier Wallet
+    And the holder is <using the app>
+    When the mobile phone does not have an internet connection
+    Then they are presented with a dismissible "no internet connection" toast notification
+
+    Examples:
+      | using the app        |
+      | Onboarding           |
+      | PIN Setup            |
+      | Receiving Credential |
+      | Presenting Proof     |
+
+
+  @T003-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @AndroidOnly
+  Scenario Outline: BC Wallet is offline and returns back online
+    Given the Holder has setup thier Wallet
+    And the holder is <using the app>
+    And the mobile phone does not have an internet connection
+    When BC Wallet suddenly goes back online
+    Then they are presented with a temporary "Your internet connection is back" toast notification
+    And the toast notification goes away after "5" seconds
+
+    Examples:
+      | using the app        |
+      | Onboarding           |
+      | PIN Setup            |
+      | Receiving Credential |
+      | Presenting Proof     |
+
+
+  @T004-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl
+  Scenario Outline: BC Wallet is offline and holder changes screens optional
+    Given the Holder has setup thier Wallet
+    And the mobile phone does not have an internet connection
+    When the holder navigates from one <screen> to <another screen>
+    Then they are presented with a dismissible "no internet connection" toast notification
+
+    Examples:
+      | screen               | another screen |
+      | Onboarding           | PIN Setup      |
+      | PIN Entry            | Home           |
+      | Home                 | Settings       |
+      | Receiving Credential | Home           |
+      | Presenting Proof     | Home           |
+
+
+
+  # SCENARIOS BELOW ARE NOT FINALIZED YET.
+  @Story_414 @wip
+  Scenario: BC Wallet is offline during a credential offer
+    Given the BC Wallet is offline
+    And the Holder is completing a credential offer
+    When the Holder selects "accept" (the accept button is not disabled)
+    Then the Holder is presented with a modal that states "You'll receive your credential in your wallet when you're back online"
+    And a "okay" button
+
+  @Story_413 @wip
+  Scenario: BC Wallet is offline during a credential offer
+    Given the holder has accepted a credential offer while offline
+    When BC Wallet has gone back online
+    And the credential offer flow is completed in the background
+    Then a notification appears in the notification section of the Home stating: "New credential added to your wallet"
+
+  @Story_392 @wip @walk
+  Scenario: The Holder uses the wallet while BC Wallet is offline
+    Given the BC Wallet is offline
+    When the Holder selects "Scan"
+    Then they are presented with a dismissible notification modal
+
+  @Story_392 @wip @walk
+  Scenario: The Holder uses the wallet while BC Wallet is offline
+    Given the BC Wallet is offline
+    And the the Holder is in proof request screen
+    When the Holder selects "Send"
+    Then they are presented with a dismissible notification modal
+
+  @Story_392 @wip @walk
+  Scenario: The Holder uses the wallet while BC Wallet is offline
+    Given the BC Wallet is offline
+    When the Holder selects a contacts chat button (speech bubble)
+    Then they move to the chat of the contact
+    And an offline error notification appears
+    And the send button is disabled
+
+  @Story_392 @wip @walk
+  Scenario: The Holder uses the wallet while BC Wallet is offline
+    Given the BC Wallet is offline
+    And the the Holder is in credential offer screen
+    When the Holder selects "Accept offer"
+    Then they are presented with a dismissible notification modal that states "You're unable to access services using BC Wallet or receive credentials until you're back online. Please check you internet connection."
+
+  @Story_392 @wip @walk
+  Scenario: The Holder uses the wallet while BC Wallet is offline
+    Given the holder waiting for a transaction to complete
+    When BC Wallet goes offline
+    Then they are presented with an error notification stating that they have "no internet connection"
+
+  @Story_392 @wip @run
+  Scenario: BC Wallet is offline during a credential offer
+    Given the BC Wallet is offline
+    And the Holder is completing a credential offer
+    When the Holder selects "accept" (the accept button is not disabled)
+    Then the Holder is presented with a modal that states "You'll receive your credential in your wallet when you're back online"
+    And a "okay" button
+
+  @Story_392 @wip @run
+  Scenario: BC Wallet is offline during an acceptance of a credential offer
+    Given the holder has accepted a credential offer while offline
+    When BC Wallet has gone back online
+    And the credential offer flow is completed in the background
+    Then a notification appears in the notification section of the Home stating: "New credential added to your wallet"

--- a/aries-mobile-tests/features/bc_wallet/offline_handling.feature
+++ b/aries-mobile-tests/features/bc_wallet/offline_handling.feature
@@ -10,21 +10,24 @@ Feature: Wallet Offline Handling
   I want to to know when I loose internet connectivity
 
 
-  @T001-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @AndroidOnly
+  # This test will remain flacky until we are out of the crawl stage and the test code is refined to properly
+  # use swipe to toggle WiFi on control center on iOS. 
+  # Android in SL has issues when coming back into a closed app, biometrics at times does not display.
+  @T001-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl
   Scenario: Holder opens BC Wallet while mobile phone is offline
     Given the Holder has setup thier Wallet
+    And the Holder has selected to use biometrics to unlock BC Wallet
     And they have closed the app
     And the mobile phone does not have an internet connection
     When the holder opens BC Wallet
-    And authenticates with thier PIN as "369369"
-    And initialization ends (failing silently)
+    #And authenticates with thier biometrics
+    #And initialization ends (failing silently)
     Then they are presented with a dismissible "no internet connection" toast notification
 
 
-  @T002-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @AndroidOnly
+  @T002-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl
   Scenario Outline: BC Wallet does not detect internet connection while in use
-    Given the Holder has setup thier Wallet
-    And the holder is <using the app>
+    Given the holder is <using the app>
     When the mobile phone does not have an internet connection
     Then they are presented with a dismissible "no internet connection" toast notification
 
@@ -36,10 +39,9 @@ Feature: Wallet Offline Handling
       | Presenting Proof     |
 
 
-  @T003-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @AndroidOnly
+  @T003-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @wip
   Scenario Outline: BC Wallet is offline and returns back online
-    Given the Holder has setup thier Wallet
-    And the holder is <using the app>
+    Given the holder is <using the app>
     And the mobile phone does not have an internet connection
     When BC Wallet suddenly goes back online
     Then they are presented with a temporary "Your internet connection is back" toast notification
@@ -53,7 +55,7 @@ Feature: Wallet Offline Handling
       | Presenting Proof     |
 
 
-  @T004-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl
+  @T004-OfflineHandling @critical @AcceptanceTest @Story_386 @crawl @wip
   Scenario Outline: BC Wallet is offline and holder changes screens optional
     Given the Holder has setup thier Wallet
     And the mobile phone does not have an internet connection

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -7,6 +7,7 @@ from unittest import IsolatedAsyncioTestCase
 from behave import given, when, then
 import json
 import os
+from time import sleep
 
 # Local Imports
 from agent_controller_client import agent_controller_GET, agent_controller_POST, expected_agent_state, setup_already_connected
@@ -16,65 +17,62 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from appium.webdriver.common.touch_action import TouchAction
 # import Page Objects needed
+from pageobjects.bc_wallet.no_internet_toast_notification import NoInternetConnectionToastNotification
 
-
+@when('the mobile phone does not have an internet connection')
 @given('the mobile phone does not have an internet connection')
 def step_impl(context):
     if context.driver.capabilities['platformName'] == 'iOS':
-        # window_size = context.driver.get_window_size()  # this returns dictionary
-        # el = context.driver.find_element(*self.configuration.CommonScreen.WEB_VIEW)
-        # action = TouchAction(self.driver)
-        # start_x = window_size["width"] * 0.5
-        # start_y = window_size["height"]
-        # end_x = window_size["width"] * 0.5
-        # end_y = window_size["height"] * 0.5
-        # action.press(el, start_x, start_y).wait(100).move_to(el, end_x, end_y).release().perform()
-
-        # height = context.driver.findElementByClassName(
-        #     "UIAWindow").getSize().getHeight()
-
         height = WebDriverWait(context.driver, 30).until(
-            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
-        ).size["height"]
-
-        # width = context.driver.findElementByClassName(
-        #     "UIAWindow").getSize().getWidth()
-
+                EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+            ).size["height"]
         width = WebDriverWait(context.driver, 30).until(
-            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
-        ).size["width"]
+                EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+            ).size["width"]
+        if '6' in context.driver.capabilities['testobject_device_name']:
+            # Access Control panel with a swipe up from the bottom
+            #context.driver.swipe(width-(width * .13), 0, height-(height * .60), height*.75, 500)
+            #context.driver.swipe(width-(width * .5), 0, height-(height * .50), height*.5, 500)
+            context.driver.swipe(width-100, height, width-100, height-200, 500);
+            actions = TouchAction(context.driver)
+            actions.tap(x = width * .25, y = height * .30).release().perform() #Wi-Fi
+            #actions.tap(x = width * .50, y = height * .65).release().perform() #Click ok on possible turn off for a day.
+            actions.tap(x = width * .75, y = height * .75).release().perform() # close control panel 
+        else:
+            # Access Control Center by Swiping down from the upper right corner
 
-        # Swipe up from the bottom - older iphones
-        #context.driver.swipe(width-100, height, width-100, height-200, 500)
-        # Swipe down from the top right - newer iphones
-        #context.driver.swipe(width-50, 0, width-50, 0+200, 500)
-        context.driver.swipe(width-(width * .13), 0, height-(height * .60), height*.5, 500)
-        #context.driver.swipe(width, startPoint, width, endPoint, duration)
-        # context.driver.findElementByAccessibilityId("Wi-Fi").click()
+            # window_size = context.driver.get_window_size()  # this returns dictionary
+            # el = context.driver.find_element(*self.configuration.CommonScreen.WEB_VIEW)
+            # action = TouchAction(self.driver)
+            # start_x = window_size["width"] * 0.5
+            # start_y = window_size["height"]
+            # end_x = window_size["width"] * 0.5
+            # end_y = window_size["height"] * 0.5
+            # action.press(el, start_x, start_y).wait(100).move_to(el, end_x, end_y).release().perform()
 
-        actions = TouchAction(context.driver)
-        #actions.tap(x = width * .25, y = height * .25).release().perform() #airplane mode
-        actions.tap(x = width * .25, y = height * .30).release().perform() #Wi-Fi
-        actions.tap(x = width * .50, y = height * .65).release().perform() #Click ok on possible turn off for a day.
-        actions.tap(x = width * .75, y = height * .75).release().perform() # close control panel 
-        # actions.tap_and_hold(20, 20)
-        # actions.move_to(10, 100)
-        # actions.release()
-        # actions.perform()
+            # height = context.driver.findElementByClassName(
+            #     "UIAWindow").getSize().getHeight()
 
+            # width = context.driver.findElementByClassName(
+            #     "UIAWindow").getSize().getWidth()
 
-        # WebDriverWait(context.driver, 30).until(
-        #     EC.presence_of_element_located(
-        #         (MobileBy.ACCESSIBILITY_ID, "Airplane Mode"))
-        # ).click()
-        # WebDriverWait(context.driver, 30).until(
-        #     EC.presence_of_element_located(
-        #         (MobileBy.IOS_PREDICATE, "name CONTAINS 'Wi-Fi'"))
-        # ).click()
-        # WebDriverWait(context.driver, 30).until(
-        #     EC.presence_of_element_located(
-        #         (MobileBy.XPATH, "//[starts-with(@id, 'Wi-Fi')]"))
-        # ).click()
+            # Swipe up from the bottom - older iphones
+            #context.driver.swipe(width-100, height, width-100, height-200, 500)
+            # Swipe down from the top right - newer iphones
+            #context.driver.swipe(width-50, 0, width-50, 0+200, 500)
+            context.driver.swipe(width-(width * .13), 0, height-(height * .60), height*.75, 500)
+            #context.driver.swipe(width, startPoint, width, endPoint, duration)
+            # context.driver.findElementByAccessibilityId("Wi-Fi").click()
+
+            actions = TouchAction(context.driver)
+            #actions.tap(x = width * .25, y = height * .25).release().perform() #airplane mode
+            actions.tap(x = width * .25, y = height * .30).release().perform() #Wi-Fi
+            actions.tap(x = width * .50, y = height * .65).release().perform() #Click ok on possible turn off for a day.
+            actions.tap(x = width * .75, y = height * .75).release().perform() # close control panel 
+            # actions.tap_and_hold(20, 20)
+            # actions.move_to(10, 100)
+            # actions.release()
+            # actions.perform()
 
     else:
         context.driver.set_network_connection(0)
@@ -107,4 +105,55 @@ def step_impl(context):
 
 @then('they are presented with a dismissible "{no_internet_connection_msg}" toast notification')
 def step_impl(context, no_internet_connection_msg):
-    pass
+    if hasattr(context, 'thisNoInternetNotification') == False:
+        context.thisNoInternetNotification = NoInternetConnectionToastNotification(context.driver)
+
+    # Notification Should be displayed
+    assert context.thisNoInternetNotification.on_this_page()
+    # Close the notification by clicking on it
+    context.thisNoInternetNotification.dismiss_notification()
+    # Check to make sure the notification is gone
+    sleep(5)
+    assert context.thisNoInternetNotification.on_this_page() == False
+
+
+@given('the holder is {using_the_app}')
+@given('the holder is "{using_the_app}"')
+def step_impl(context, using_the_app):
+    if using_the_app == "Onboarding":
+        context.execute_steps(f'''
+            Given the new user has opened the app for the first time
+            And the user is on the onboarding {'Share only what is neccessary screen'}
+        ''')
+    elif using_the_app == "PIN Setup":
+        context.execute_steps(f'''
+            Given the User has skipped on-boarding
+            And the User has accepted the Terms and Conditions
+            And the User is on the PIN creation screen
+        ''')
+    elif using_the_app == "Receiving Credential":
+        context.execute_steps(f'''
+            Given the User has skipped on-boarding
+            And the User has accepted the Terms and Conditions
+            And a PIN has been set up with "369369"
+            And the Holder has selected to use biometrics to unlock BC Wallet
+            And a connection has been successfully made
+            And the user has a credential offer
+            When they select Accept
+            And the holder is informed that their credential is on the way with an indication of loading
+        ''')
+    elif using_the_app == "Presenting Proof":
+        context.execute_steps(f'''
+            Given the User has skipped on-boarding
+            And the User has accepted the Terms and Conditions
+            And a PIN has been set up with "369369"
+            And the Holder has selected to use biometrics to unlock BC Wallet
+            And a connection has been successfully made
+            And the holder has a Non-Revocable credential
+                | issuer_agent_type | credential_name                           |
+                | AATHIssuer        | Default AATH Issuer Credential Definition |
+            And the user has a proof request
+            When they select Share
+            And the holder is informed that they are sending information securely
+        ''')
+

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -1,0 +1,110 @@
+# -----------------------------------------------------------
+# Behave Step Definitions for Offline Handling Steps.
+#
+# -----------------------------------------------------------
+
+from unittest import IsolatedAsyncioTestCase
+from behave import given, when, then
+import json
+import os
+
+# Local Imports
+from agent_controller_client import agent_controller_GET, agent_controller_POST, expected_agent_state, setup_already_connected
+from agent_test_utils import get_qr_code_from_invitation
+from appium.webdriver.common.mobileby import MobileBy
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from appium.webdriver.common.touch_action import TouchAction
+# import Page Objects needed
+
+
+@given('the mobile phone does not have an internet connection')
+def step_impl(context):
+    if context.driver.capabilities['platformName'] == 'iOS':
+        # window_size = context.driver.get_window_size()  # this returns dictionary
+        # el = context.driver.find_element(*self.configuration.CommonScreen.WEB_VIEW)
+        # action = TouchAction(self.driver)
+        # start_x = window_size["width"] * 0.5
+        # start_y = window_size["height"]
+        # end_x = window_size["width"] * 0.5
+        # end_y = window_size["height"] * 0.5
+        # action.press(el, start_x, start_y).wait(100).move_to(el, end_x, end_y).release().perform()
+
+        # height = context.driver.findElementByClassName(
+        #     "UIAWindow").getSize().getHeight()
+
+        height = WebDriverWait(context.driver, 30).until(
+            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+        ).size["height"]
+
+        # width = context.driver.findElementByClassName(
+        #     "UIAWindow").getSize().getWidth()
+
+        width = WebDriverWait(context.driver, 30).until(
+            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+        ).size["width"]
+
+        # Swipe up from the bottom - older iphones
+        #context.driver.swipe(width-100, height, width-100, height-200, 500)
+        # Swipe down from the top right - newer iphones
+        #context.driver.swipe(width-50, 0, width-50, 0+200, 500)
+        context.driver.swipe(width-(width * .13), 0, height-(height * .60), height*.5, 500)
+        #context.driver.swipe(width, startPoint, width, endPoint, duration)
+        # context.driver.findElementByAccessibilityId("Wi-Fi").click()
+
+        actions = TouchAction(context.driver)
+        #actions.tap(x = width * .25, y = height * .25).release().perform() #airplane mode
+        actions.tap(x = width * .25, y = height * .30).release().perform() #Wi-Fi
+        actions.tap(x = width * .50, y = height * .65).release().perform() #Click ok on possible turn off for a day.
+        actions.tap(x = width * .75, y = height * .75).release().perform() # close control panel 
+        # actions.tap_and_hold(20, 20)
+        # actions.move_to(10, 100)
+        # actions.release()
+        # actions.perform()
+
+
+        # WebDriverWait(context.driver, 30).until(
+        #     EC.presence_of_element_located(
+        #         (MobileBy.ACCESSIBILITY_ID, "Airplane Mode"))
+        # ).click()
+        # WebDriverWait(context.driver, 30).until(
+        #     EC.presence_of_element_located(
+        #         (MobileBy.IOS_PREDICATE, "name CONTAINS 'Wi-Fi'"))
+        # ).click()
+        # WebDriverWait(context.driver, 30).until(
+        #     EC.presence_of_element_located(
+        #         (MobileBy.XPATH, "//[starts-with(@id, 'Wi-Fi')]"))
+        # ).click()
+
+    else:
+        context.driver.set_network_connection(0)
+
+
+@when('BC Wallet suddenly goes back online')
+def step_impl(context):
+    if context.driver.capabilities['platformName'] == 'iOS':
+        # Get screen height
+        height = WebDriverWait(context.driver, 30).until(
+            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+        ).size["height"]
+        # Get screen width
+        width = WebDriverWait(context.driver, 30).until(
+            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+        ).size["width"]
+
+        # swipe down on the right to open control center
+        context.driver.swipe(width-50, 0, width-50, 0+200, 500)
+
+        action = TouchAction(context.driver)
+        # tap Wi-Fi to turn on
+        action.tap(x = width * .25, y = height * .30).release().perform()
+        # tap in empty space to close control center
+        action.tap(x = width * .75, y = height * .75).release().perform() # close control panel 
+
+    else:
+        context.driver.set_network_connection(6)
+
+
+@then('they are presented with a dismissible "{no_internet_connection_msg}" toast notification')
+def step_impl(context, no_internet_connection_msg):
+    pass

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -58,7 +58,8 @@ def step_impl(context):
     context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
     #context.device_service_handler.biometrics_authenticate(True)
 
-@then('they land on the Home screen')
+
+@when('initialization ends (failing silently')
 @then('they have access to the app')
 @then('the User has successfully created a PIN')
 def step_impl(context):
@@ -90,6 +91,7 @@ def step_impl(context):
         context.driver.close_app()
 
 
+@when('the holder opens BC Wallet')
 @when('they relaunch the app')
 def step_impl(context):
     if context.driver.capabilities['platformName'] == 'iOS':

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -58,8 +58,8 @@ def step_impl(context):
     context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
     #context.device_service_handler.biometrics_authenticate(True)
 
-
-@when('initialization ends (failing silently')
+@then('they land on the Home screen')
+@when('initialization ends (failing silently)')
 @then('they have access to the app')
 @then('the User has successfully created a PIN')
 def step_impl(context):

--- a/aries-mobile-tests/pageobjects/bc_wallet/no_internet_toast_notification.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/no_internet_toast_notification.py
@@ -1,0 +1,11 @@
+from appium.webdriver.common.mobileby import MobileBy
+from pageobjects.bc_wallet.toast_notification import ToastNotification
+
+class NoInternetConnectionToastNotification(ToastNotification):
+    """No Internet Connection toast notification page object"""
+
+    # Locators
+    on_this_page_text_locator = "No internet connection"
+    notification_locator = (MobileBy.ID, "com.ariesbifold:id/ToastTitle")
+
+

--- a/aries-mobile-tests/pageobjects/bc_wallet/toast_notification.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/toast_notification.py
@@ -1,0 +1,29 @@
+import os
+import time
+from appium.webdriver.common.mobileby import MobileBy
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from pageobjects.basepage import BasePage
+from pageobjects.bc_wallet.pinsetup import PINSetupPage
+from pageobjects.bc_wallet.initialization import InitializationPage
+
+class ToastNotification(BasePage):
+    """base class for the toast notification page object"""
+
+    # Locators
+    on_this_page_text_locator:str
+    notification_locator:tuple
+
+    def on_this_page(self):   
+        timeout = 50
+        if "Local" in os.environ['DEVICE_CLOUD']:
+            timeout = 100
+        return super().on_this_page(self.on_this_page_text_locator, timeout)  
+
+    def dismiss_notification(self):
+        if self.on_this_page():
+            self.find_by(self.notification_locator).click()
+            # Not sure what is returned here yet
+            # return CredentialOfferPage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)} page")


### PR DESCRIPTION
Initial set of Offline handling of the BC Wallet tests. These may remain flaky on iOS until we are out of the crawl stage and the test code is refined to properly use swipe to toggle WiFi on control center on iOS. 
Android in SL has issues when coming back into a closed app, biometrics at times does not display.