### PR TITLE
fix Android issues with modals

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -88,9 +88,9 @@ Feature: Secure your Wallet
 
     Examples:
       # TODO add more examples
-      | pin    | pin_error                             |
-      | 2357   | Your PIN must be six digits in length |
-      | 27463A | Please use only numbers in your PIN   |
+      | pin    | pin_error                           |
+      | 2357   | Your PIN needs to be 6 digits long. |
+      | 27463A | Please use only numbers in your PIN |
     @wip
     Examples:
       | 000000 | Please use only number in your PIN |
@@ -131,14 +131,14 @@ Feature: Secure your Wallet
 
   @Story_421 @AcceptanceTest @wip
   Scenario: Holder selects biometrics option in Onbarding with a device that didn't have biometrics setup beforehand
-  Scenario: Holder does not have biometrics setup in their wallet
+    #Scenario: Holder does not have biometrics setup in their wallet
     Given the Holder does not have biometrics setup in their wallet
     When the Holder selects to use biometrics to unlock BC Wallet
     Then a notification pops up stating that they do not have biometrics unlock and to add it in phone settings
 
   @Story_421 @AcceptanceTest @wip
-  Scenario: Holder has chooses to not use biometrics
-  Scenario: Holder has chooses to use PIN instead of biometrics
+  #Scenario: Holder has chooses to not use biometrics
+  Scenario: Holder chooses to use PIN instead of biometrics
     Given the Holder has selected to use Wallet PIN only to unlock BC Wallet
     When the Holder opens the app
     Then they are prompted to input their wallet PIN

--- a/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
@@ -127,14 +127,14 @@ def step_impl(context):
 @when('once the credential arrives they are informed that the Credential is added to your wallet')
 def step_impl(context):
     # The Cred is on the way screen is temporary, loop until it goes away and create the cred added page.
-    timeout=30
+    timeout=40
     i=0
     while context.thisCredentialOnTheWayPage.on_this_page() and i < timeout:
         # need to break out here incase we are stuck on connecting? 
         # if we are too long, we need to click the Go back to home button.
         sleep(1)
         i+=1
-    if i == 30: # we timed out and it is still connecting
+    if i == 40: # we timed out and it is still connecting
         context.thisHomePage = context.thisCredentialOnTheWayPage.select_home()
     else:
         #assume credential added 

--- a/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
@@ -1,10 +1,5 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.home import HomePage
-from pageobjects.bc_wallet.initialization import InitializationPage
 from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
 
 
@@ -12,44 +7,27 @@ class PINSetupPage(BasePage):
     """PIN Setup page object"""
 
     # Locators
-    #on_this_page_text_locator = "Enter Pin"
     on_this_page_text_locator = "Remember your PIN"
-    #first_pin_locator = (MobileBy.ACCESSIBILITY_ID, "Enter a 6 digit PIN-1")
-    first_pin_locator = (MobileBy.ID, "com.ariesbifold:id/EnterPIN")
+    on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/ReenterPIN")
+    first_pin_locator = (AppiumBy.ID, "com.ariesbifold:id/EnterPIN")
     first_pin_visibility_locator = (
-        MobileBy.ID, "com.ariesbifold:id/EnterPINVisability")
-    #second_pin_locator = (MobileBy.ACCESSIBILITY_ID, "Re-Enter PIN-1")
-    second_pin_locator = (MobileBy.ID, "com.ariesbifold:id/ReenterPIN")
+        AppiumBy.ID, "com.ariesbifold:id/EnterPINVisability")
+    second_pin_locator = (AppiumBy.ID, "com.ariesbifold:id/ReenterPIN")
     second_pin_visibility_locator = (
-        MobileBy.ID, "com.ariesbifold:id/ReenterPINVisability")
-    #create_pin_button_aid_locator = "Create"
+        AppiumBy.ID, "com.ariesbifold:id/ReenterPINVisability")
     create_pin_button_tid_locator = (
-        MobileBy.ID, "com.ariesbifold:id/CreatePIN")
+        AppiumBy.ID, "com.ariesbifold:id/CreatePIN")
     modal_message_title_locator = (
-        MobileBy.ID, "com.ariesbifold:id/HeaderText")
-    modal_message_body_locator = (MobileBy.ID, "com.ariesbifold:id/BodyText")
-    modal_message_ok_locator = (MobileBy.ID, "com.ariesbifold:id/Okay")
+        AppiumBy.ID, "com.ariesbifold:id/HeaderText")
+    modal_message_body_locator = (AppiumBy.ID, "com.ariesbifold:id/BodyText")
+    modal_message_ok_locator = (AppiumBy.ID, "com.ariesbifold:id/Okay")
 
     def on_this_page(self):
-        # print(self.driver.page_source)
-        return super().on_this_page(self.on_this_page_text_locator)
+        return super().on_this_page(self.on_this_page_locator)
 
     def enter_pin(self, pin):
         if self.on_this_page():
-            # self.find_by_element_id("com.ariesbifold:id/EnterPIN-1").send_keys("3")
-            # self.find_by_element_id("com.ariesbifold:id/EnterPIN-2").send_keys("6")
-            # self.find_by_element_id("com.ariesbifold:id/EnterPIN-3").send_keys("9")
-            # self.find_by_element_id("com.ariesbifold:id/EnterPIN-4").send_keys("3")
-            # self.find_by_element_id("com.ariesbifold:id/EnterPIN-5").send_keys("6")
-            # self.find_by_element_id("com.ariesbifold:id/EnterPIN-6").send_keys("9")
-            # self.find_by_element_id("com.ariesbifold:id/ReenterPIN-1").send_keys("3")
-            # self.find_by_element_id("com.ariesbifold:id/ReenterPIN-2").send_keys("6")
-            # self.find_by_element_id("com.ariesbifold:id/ReenterPIN-3").send_keys("9")
-            # self.find_by_element_id("com.ariesbifold:id/ReenterPIN-4").send_keys("3")
-            # self.find_by_element_id("com.ariesbifold:id/ReenterPIN-5").send_keys("6")
-            # self.find_by_element_id("com.ariesbifold:id/ReenterPIN-6").send_keys("9")
             self.find_by(self.first_pin_locator).send_keys(pin)
-            # self.find_by(self.first_pin_tid_locator).set_value(pin)
             return True
         else:
             raise Exception(f"App not on the {type(self)} page")
@@ -60,7 +38,6 @@ class PINSetupPage(BasePage):
             self.find_by(self.first_pin_visibility_locator).click()
             size = len(self.first_pin_locator[1])
             return self._construct_pin_from_boxes(self.first_pin_aid_locator[1][:size - 2])
-            # return self.find_by(self.first_pin_tid_locator).text
         else:
             raise Exception(f"App not on the {type(self)} page")
 
@@ -68,12 +45,6 @@ class PINSetupPage(BasePage):
         if self.on_this_page():
             self.find_by(self.second_pin_locator).click()
             self.find_by(self.second_pin_locator).send_keys(pin)
-            # element = self.find_by(self.second_pin_locator)
-            # element.clear()
-            # element.set_value('3')
-            # element.click()
-            # self.driver.getKeyboard().sendKeys("3")
-            # element.type()
             return True
         else:
             raise Exception(f"App not on the {type(self)} page")
@@ -107,23 +78,24 @@ class PINSetupPage(BasePage):
             raise Exception(f"App not on the {type(self)} page")
 
     def select_ok_on_modal(self):
-        if self.on_this_page():
-            self.find_by(self.modal_message_ok_locator).click()
+        # On Android the modal hides all the other PIN setup page elements, so we can't check on this page
+        # if self.on_this_page():
+        self.find_by(self.modal_message_ok_locator).click()
 
-            # return the wallet initialization page
-            return True
-        else:
-            raise Exception(f"App not on the {type(self)} page")
+        return True
+        # else:
+        #     raise Exception(f"App not on the {type(self)} page")
 
     def get_pin_error(self):
-        if self.on_this_page():
-            return self.find_by(self.modal_message_body_locator).text
-        else:
-            raise Exception(f"App not on the {type(self)} page")
+        # On Android the modal hides all the other PIN setup page elements, so we can't check on this page
+        # if self.on_this_page():
+        return self.find_by(self.modal_message_body_locator).text
+        # else:
+        #     raise Exception(f"App not on the {type(self)} page")
 
-    def _construct_pin_from_boxes(self, pin_locator, find_by=MobileBy.ID, pin_length=6):
+    def _construct_pin_from_boxes(self, pin_locator, find_by=AppiumBy.ID, pin_length=6):
         pin = ""
-        if find_by == MobileBy.ID:
+        if find_by == AppiumBy.ID:
             find_by_routine = getattr(self, "find_by_element_id")
         else:
             find_by_routine = getattr(self, "find_by_accessibility_id")


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR fixes BC Wallet test issues. One is access to the underlying page object is not accessible on android when a modal is displayed. This is different than on iOS. 

The other issue is On android the credential receiving takes longer than iOS, so a timeout increase was done. 

Another issue was @wip security tests were running because of double `Scenario` clauses on the tests.