### PR TITLE
Added biometrics authrnticate after onboarding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,19 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: run-aath-agents
+        if: ${{ matrix.mobile-platform=='-p iOS' }}
         uses: ./.github/workflows/run-aath-agents
         with:
           USE_NGROK: ""
 
+      - name: run-aath-agents-ngrok
+        if: ${{ matrix.mobile-platform=='-p Android' }}
+        uses: ./.github/workflows/run-aath-agents
+        with:
+          USE_NGROK: "-n"
+
       - name: run-sauce-connect-tunnel
+        if: ${{ matrix.mobile-platform=='-p iOS' }}
         uses: saucelabs/sauce-connect-action@v2
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
@@ -96,6 +104,7 @@ jobs:
         continue-on-error: true
 
       - name: Shutdown Sauce Connect Tunnel
+        if: ${{ matrix.mobile-platform=='-p iOS' }}
         run: |
           docker ps \
           --format '{{.ID}} {{.Image}}' | \

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -57,7 +57,7 @@ def step_impl(context):
 def step_impl(context):
     assert context.thisOnboardingBiometricsPage.select_biometrics()
     context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
-    #context.device_service_handler.biometrics_authenticate(True)
+    context.device_service_handler.biometrics_authenticate(True)
 
 @then('they land on the Home screen')
 @when('initialization ends (failing silently)')


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Calibrating to BC Wallet build 404 required the addition of biometrics authentication right after selecting to enable biometrics and clicking continue. 

This PR also includes the removal of the Sauce Labs tunnel for android test, reverting back to ngrok, which seems to work better for android when scanning the QR code.