### PR TITLE
update to affect the BCSC runset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
           DEVICE_CLOUD_KEY: "-k ${{ secrets.SAUCE_ACCESS_KEY }}"
           MOBILE_PLATFORM: ${{ matrix.mobile-platform }}
           APP_FILE_NAME: ${{ matrix.app-file-name }}
-          TEST_SCOPE: "-t @bc_wallet,@Connectionless -t ~@wip -t ~@BCSC"
+          TEST_SCOPE: "-t @bc_wallet -t @Connectionless -t ~@wip -t ~@BCSC"
           REPORT_PROJECT: ${{ matrix.report-project }}
         continue-on-error: true
 
@@ -163,7 +163,7 @@ jobs:
           DEVICE_CLOUD_KEY: "-k ${{ secrets.SAUCE_ACCESS_KEY }}"
           MOBILE_PLATFORM: ${{ matrix.mobile-platform }}
           APP_FILE_NAME: ${{ matrix.app-file-name }}
-          TEST_SCOPE: "-t @bc_wallet,@BCSC -t ~@wip"
+          TEST_SCOPE: "-t @bc_wallet -t @BCSC -t ~@wip"
           REPORT_PROJECT: ${{ matrix.report-project }}
         continue-on-error: true
 

--- a/aries-mobile-tests/features/bc_wallet/bcsc.feature
+++ b/aries-mobile-tests/features/bc_wallet/bcsc.feature
@@ -11,8 +11,8 @@ Feature: BCSC
    Scenario Outline: BCSC holder aquires BC VC Certificate that in turn allows them to store the BCSC in the BC Wallet
       Given the BCSC holder has setup thier Wallet
       And the BCSC holder has a <credential>
-         | issuer_agent_type | credential_name         |
-         | BCVPIssuer        | BC VC Pilot Certificate |
+         | issuer_agent_type | credential_name  |
+         | BCVPIssuer        | Pilot Invitation |
       And they are Home
       When they select Get your BC Digital ID
       And they select Share on the proof request from IDIM
@@ -33,8 +33,8 @@ Feature: BCSC
          | issuer_agent_type | credential_name |
          | BCVPIssuer        | Person          |
       And the BCVC Pilot credential is after the IDIM Person credential
-         | issuer_agent_type | credential_name         |
-         | BCVPIssuer        | BC VC Pilot Certificate |
+         | issuer_agent_type | credential_name  |
+         | BCVPIssuer        | Pilot Invitation |
 
       # username and passwords are pointers to env vars that hold the actual values
       Examples:
@@ -42,8 +42,8 @@ Feature: BCSC
          | Test with username and password | BCSC_ACCOUNT_USER | BCSC_ACCOUNT_PASSWORD |
 
 
-   @T00X-BCSC @Normal @FunctionalTest
+   @T00X-BCSC @Normal @FunctionalTest @wip
    Scenario: BCSC holder removes the IDIM Person credential and can get the IDIM credential again with the button on the home page
 
-   @T00X-BCSC @Normal @FunctionalTest
+   @T00X-BCSC @Normal @FunctionalTest @wip
    Scenario: BCSC holder removes the IDIM Person credential and the BCVC Certificate and can get the IDIM credential again repeating the credential request

--- a/aries-mobile-tests/pageobjects/bc_wallet/holder_get_invite_interface/pageobjects/bc_vc_invitation_agree_page.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/holder_get_invite_interface/pageobjects/bc_vc_invitation_agree_page.py
@@ -8,11 +8,11 @@ class BCVCInvitationAgreePage(WebBasePage):
 
     # Locators
     on_this_page_text_locator = "BC VC Pilot Credential"
-    i_agree_locator = (By.XPATH, '//*[@id="app"]/div/main/div/div/div/div[2]/div[1]/div/div/div/div[1]/div/div')
+    #i_agree_locator = (By.XPATH, '//*[@id="app"]/div/main/div/div/div/div[2]/div[1]/div/div/div/div[1]/div/div')
+    i_agree_locator = (By.XPATH, '//div[@class="v-input--selection-controls__ripple"]')
 
-    agree_locator = (By.XPATH, '//*[@id="app"]/div/main/div/div/div/div[2]/div[2]/div/a')
-    #//*[@id="app"]/div/main/div/div/div/div[2]/div[2]/div/a
-    #/html/body/div/div/main/div/div/div/div[2]/div[2]/div/a
+    #agree_locator = (By.XPATH, '//*[@id="app"]/div/main/div/div/div/div[2]/div[2]/div/a')
+    agree_locator = (By.XPATH, '//a[@class="v-btn v-btn--outlined v-btn--router theme--light v-size--default success--text"]')
 
 
     def on_this_page(self):    


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Update to for the BC Services Card/Person credential BC Wallet tests in the nightly test pipeline. Added `@wip` to unfinished scenarios and changed the tag set in the run command, along with updated credential names for the Person credential. 