### PR TITLE
restrict matrix entry in main run all runset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
       #       saucelabs/sauce-connect
 
       - name: Run AMTH All Tests
+        if: ${{ contains(matrix.report-project,'multi-device-full') }}
         uses: ./.github/workflows/run-test-harness
         env:
           LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Added if condition to the main run all runset for BC Wallet test pipeline. That runset was running for all projects giving all the results for all tests in restricted runsets with different issuers. 