### PR TITLE
fix webdriver-manager package issue and calibrate to 447

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/bcsc.feature
+++ b/aries-mobile-tests/features/bc_wallet/bcsc.feature
@@ -22,8 +22,8 @@ Feature: BCSC
       And they enter in <password> as the password
       And they select I agree on the Review page
       And they select Send Credential
-      Then they get are told Your Credential has been Issued
-      And they Close and go to Wallet
+      #Then they get are told Your Credential has been Issued
+      Then they Close and go to Wallet
       And they select View on the new Credential Offer
       And they select Accept
       And the holder is informed that their credential is on the way with an indication of loading

--- a/aries-mobile-tests/features/steps/bc_wallet/bcsc.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/bcsc.py
@@ -111,7 +111,8 @@ def step_impl(context):
 
 @when('they select Send Credential')
 def step_impl(context): 
-    context.thisBCServicesCardCredentialIssuedPage = context.thisBCServicesCardReviewPage.send_credential()
+    #context.thisBCServicesCardCredentialIssuedPage = context.thisBCServicesCardReviewPage.send_credential()
+    context.thisInformationSentSuccessfullyPage = context.thisBCServicesCardReviewPage.send_credential()
 
 
 @then('they get are told Your Credential has been Issued')
@@ -121,7 +122,7 @@ def step_impl(context):
 # they Close and go to Wallet (select home for now)
 @then('they Close and go to Wallet')
 def step_impl(context): 
-    context.thisInformationSentSuccessfullyPage = context.thisBCServicesCardCredentialIssuedPage.close_and_go_to_wallet()
+    #context.thisInformationSentSuccessfullyPage = context.thisBCServicesCardCredentialIssuedPage.close_and_go_to_wallet()
     context.execute_steps('''
         When they select Go back to home on information sent successfully
     ''')

--- a/aries-mobile-tests/pageobjects/bc_wallet/bc_services_card_review.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/bc_services_card_review.py
@@ -1,6 +1,7 @@
 from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.bc_services_card_credential_issued import BCServicesCardCredentialIssuedPage
+from pageobjects.bc_wallet.information_sent_successfully import InformationSentSuccessfullyPage
 
 class BCServicesCardReviewPage(BasePage):
     """BC Services Card Login with Username and Password page object"""
@@ -26,6 +27,7 @@ class BCServicesCardReviewPage(BasePage):
     def send_credential(self):
         if self.on_this_page():
             self.find_by(self.send_credential_locator).click()
-            return BCServicesCardCredentialIssuedPage(self.driver)
+            #return BCServicesCardCredentialIssuedPage(self.driver)
+            return InformationSentSuccessfullyPage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/navbar.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/navbar.py
@@ -10,7 +10,7 @@ class NavBar(BasePage):
 
     # Locators
     scan_locator = (AppiumBy.ACCESSIBILITY_ID, "Scan")
-    home_locator = (AppiumBy.ACCESSIBILITY_ID, "Home")
+    home_locator = (AppiumBy.ACCESSIBILITY_ID, "Home (0 Notifications)")
     credentials_locator = (AppiumBy.ACCESSIBILITY_ID, "Credentials")
     settings_locator = (AppiumBy.ACCESSIBILITY_ID, "Settings")
 

--- a/aries-mobile-tests/requirements.txt
+++ b/aries-mobile-tests/requirements.txt
@@ -11,4 +11,4 @@ psutil==5.7.2
 #Appium-Python-Client==1.0.2;python_version >= '3.0'
 Appium-Python-Client
 qrcode[pil]~=6.1
-webdriver-manager
+webdriver-manager==3.8.3


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Webdriver-manager was updated on the 18th and issues in that library caused the BC Wallet test pipeline to fail completely. Reverted to the older version.

Also calibrated the BC wallet tests to build 447. 