### PR TITLE
overcome iOS 14 cred offer testID issue

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
@@ -22,6 +22,9 @@ class CredentialOfferPage(BasePage):
 
     def on_this_page(self):
         #return super().on_this_page(self.on_this_page_text_locator, 30)
+        if self.current_platform == 'iOS':
+            if '14' in self.driver.capabilities['platformVersion']:
+                return super().on_this_page(self.on_this_page_text_locator, 30)
         return super().on_this_page(self.credential_offer_card_locator, 30)
 
     def select_accept(self, scroll=False):


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

For BC Wallet, iOS 14 is not showing Credential Card testIDs on the credential offer screen. Implemented a workaround that just checks for text in the page source. 