### PR TITLE
trial fix for getting auth code for BC VP issuer

### DIFF
--- a/aries-mobile-tests/agent_factory/bc_vp/bc_vp_issuer_agent_interface.py
+++ b/aries-mobile-tests/agent_factory/bc_vp/bc_vp_issuer_agent_interface.py
@@ -10,8 +10,10 @@ from selenium.webdriver.chrome.options import Options
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.utils import ChromeType
 # import Page Objects needed
+from pageobjects.bc_wallet.issuer_get_authcode_interface.bc_vp_issuer_get_authcode_interface import BCVPIssuerGetAuthCodeInterface
 from agent_factory.bc_vp.pageobjects.authenticate_with_page import AuthenticateWithPage
 from agent_factory.bc_vp.pageobjects.authenticate_page import AuthenticatePage
+from agent_factory.bc_vp.pageobjects.authcode_page import AuthCodePage
 from agent_factory.bc_vp.pageobjects.invites_page import InvitesPage
 from agent_factory.bc_vp.pageobjects.invite_page import InvitePage
 
@@ -134,6 +136,16 @@ class BC_VP_IssuerAgentInterface(IssuerAgentInterface):
         self._authenticate_page.enter_username(username)
         self._authenticate_page.enter_password(password)
         self._invites_page = self._authenticate_page.sign_in()
+
+        # if github login wants an auth code
+        auth_code_page = AuthCodePage(self.driver)
+        if auth_code_page.on_this_page():
+            issuerGetAuthCodeInterface = BCVPIssuerGetAuthCodeInterface("http://www.gmail.com")
+            auth_code =  issuerGetAuthCodeInterface.get_auth_code()
+            # close the get auth code driver
+            issuerGetAuthCodeInterface.driver.close()
+            auth_code_page = AuthCodePage()
+            auth_code_page.enter_auth_code(auth_code)
 
         if not self._invites_page.on_this_page():
             raise Exception(

--- a/aries-mobile-tests/agent_factory/bc_vp/pageobjects/authcode_page.py
+++ b/aries-mobile-tests/agent_factory/bc_vp/pageobjects/authcode_page.py
@@ -1,0 +1,22 @@
+from PIL import Image
+from agent_factory.candy_uvp.pageobjects.webbasepage import WebBasePage
+from selenium.webdriver.common.by import By
+
+# These classes can inherit from a BasePage to do commone setup and functions
+class AuthCodePage(WebBasePage):
+    """BC VP Issuer GitHub Auth Code page object"""
+
+    # Locators
+    on_this_page_text_locator = "Device verification"
+    auth_code_locator = (By.ID, 'otp')
+
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_text_locator) 
+
+    def enter_auth_code(self, auth_code):
+        if self.on_this_page():
+            self.find_by(self.auth_code_locator).send_keys(auth_code)
+            return True
+        else:
+            raise Exception(f"App not on the {type(self)} page")
+    

--- a/aries-mobile-tests/pageobjects/bc_wallet/holder_get_invite_interface/pageobjects/gmail_email_page.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/holder_get_invite_interface/pageobjects/gmail_email_page.py
@@ -1,5 +1,6 @@
 from agent_factory.candy_uvp.pageobjects.webbasepage import WebBasePage
 from selenium.webdriver.common.by import By
+import re
 #from agent_factory.bc_vp.pageobjects.invite_page import InvitePage
 from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.bc_vc_invitation_agree_page import BCVCInvitationAgreePage
 
@@ -12,6 +13,9 @@ class GmailEmailPage(WebBasePage):
     # Locators
     on_this_page_text_locator = "Primary"
     latest_email_locator = (By.ID, ":24")
+    delete_locator = (By.XPATH, "//div[@aria-label='Delete']//div[@class='asa']")
+    # auth code email locator - //body[1]/div[7]/div[3]/div[1]/div[2]/div[2]/div[1]/div[1]/div[1]/div[1]/div[2]/div[1]/div[1]/div[1]/div[1]/div[8]/div[1]/div[1]/div[2]/div[1]/table[1]/tbody[1]/tr[1]/td[5]/div[1]/div[1]/div[1]/span[1]/span[1]
+    auth_code_body_text_locator = (By.XPATH, "//div[contains(text(),'Verification code')]")
     # <span class="bqe" data-thread-id="#thread-f:1745870413865589327" data-legacy-thread-id="183a93e432529a4f" data-legacy-last-message-id="183aa57ef028fb34" data-legacy-last-non-draft-message-id="183aa57ef028fb34">Invite from BC VC Pilot Issuer TEST</span>
     #//*[@id=":24"]
     #//*[@id=":2b"]
@@ -39,3 +43,17 @@ class GmailEmailPage(WebBasePage):
             #return InvitePage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")
+
+    def get_auth_code(self):
+        #if self.on_this_page():
+        if super().on_this_page(self.auth_code_body_text_locator, timeout=1000):
+            email_body = self.find_by(self.auth_code_body_text_locator).text
+            auth_code = re.sub("\D", "", email_body)
+            return auth_code
+        else:
+            raise Exception(f"App not on the {type(self)} page")
+
+    
+    def delete_opened_email(self):
+        self.find_by(self.delete_locator, 50).click()
+

--- a/aries-mobile-tests/pageobjects/bc_wallet/issuer_get_authcode_interface/bc_vp_issuer_get_authcode_interface.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/issuer_get_authcode_interface/bc_vp_issuer_get_authcode_interface.py
@@ -1,0 +1,83 @@
+"""
+Class for interfacing with gmail client getting a IDIM Verified Person Credential certificate invitation
+"""
+from sys import platform
+from decouple import config
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.core.utils import ChromeType
+# import Page Objects needed
+from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.gmail_login_page import GmailLoginPage
+from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.gmail_email_page import GmailEmailPage
+from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.bc_vc_invitation_agree_page import BCVCInvitationAgreePage
+from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.bc_vc_invitation_request_credential_page import BCVCInvitationRequestCredentialPage
+from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.bc_vc_invitation_review_page import BCVCInvitationReviewPage
+from pageobjects.bc_wallet.holder_get_invite_interface.pageobjects.connect_with_issuer_page import ConnectWithIssuerPage
+
+
+class BCVPIssuerGetAuthCodeInterface():
+
+    _gmail_login_page: GmailLoginPage
+    _gmail_email_page: GmailEmailPage
+    _bc_vc_invitation_agree_page: BCVCInvitationAgreePage
+    _bc_vc_request_credential_page: BCVCInvitationRequestCredentialPage
+    _bc_vc_invitation_review_page: BCVCInvitationReviewPage
+    _bc_vc_qrcode_page: ConnectWithIssuerPage
+    endpoint: str
+
+    def __init__(self, endpoint):
+        # Standup Selenuim Driver with endpoint
+        self.endpoint = endpoint
+        if platform == "linux" or platform == "linux2":
+            print("Starting Chromium on linux for Issuer Agent")
+            options = Options()
+            options.add_argument("--no-sandbox")
+            # options.add_argument("--disable-dev-shm-usage")
+            options.add_argument("--headless")
+            self.driver = webdriver.Chrome(options=options, service=Service(
+                ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()))
+            #self.driver = webdriver.Chrome(options=options, service=Service(ChromeDriverManager().install()))
+        else:
+            print("Starting Chrome on Mac or Windows for Issuer Agent")
+            self.driver = webdriver.Chrome(
+                service=Service(ChromeDriverManager().install()))
+        # go to the issuer endpoint in the browser
+        self.driver.get(self.endpoint)
+        # instantiate intial page objects
+        self._gmail_login_page = GmailLoginPage(self.driver)
+        # make sure we are on the first page, the authenticate with page
+        if not self._gmail_login_page.on_this_page():
+            raise Exception(
+                'Something is wrong, not on the Gmail login Page for the BC VP Issuer')
+        username = config('BC_VP_USERNAME')
+        password = config('BC_VP_HOLDER_EMAIL_PASSWORD')
+        self._login(username, password)
+
+    def _open_auth_code_email(self):
+        """send a credential to the holder, return True if invite is successfully sent to email"""
+        self._gmail_email_page.open_latest_email()
+        return True
+
+    def get_auth_code(self):
+        """send a credential to the holder, return True if invite is successfully sent to email"""
+        self._gmail_email_page.open_latest_email()
+        auth_code = self._gmail_email_page.get_auth_code()
+        self._gmail_email_page.delete_opened_email()
+        return auth_code
+
+
+    def _login(self, username: str, password: str):
+        if not self._gmail_login_page.on_this_page():
+            raise Exception(
+                'Something is wrong, not on the Gmail login Page for the BC VP Issuer')
+
+        self._gmail_login_page.enter_username(username)
+        self._gmail_login_page.next()
+        self._gmail_login_page.enter_password(password)
+        self._gmail_email_page = self._gmail_login_page.sign_in()
+
+        if not self._gmail_email_page.on_this_page():
+            raise Exception(
+                'Something is wrong, not logged in to gmail')


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This is a fix for getting the auth code from a GitHub login on the BC VP Issuer Login when in the GitHub test pipeline environment. However, locally when logging into gmail to get the auth code, gmail is occasionally presenting a captcha. Hoping this doesn't happen in the pipeline as well. 