### PR TITLE
remove unnessesary bs4 import in gapi auth code interface

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/issuer_get_authcode_interface/bc_vp_issuer_get_authcode_interface_gapi.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/issuer_get_authcode_interface/bc_vp_issuer_get_authcode_interface_gapi.py
@@ -4,7 +4,6 @@ Class for interfacing with gmail client getting a IDIM Verified Person Credentia
 from sys import platform
 from time import sleep
 from decouple import config
-from bs4 import BeautifulSoup
 import re
 import base64
 import json
@@ -101,15 +100,9 @@ class BCVPIssuerGetAuthCodeInterface():
                 if subject == "[GitHub] Please verify your device" and sender == "GitHub <noreply@github.com>":
                     # The Body of the message is in Encrypted format. So, we have to decode it.
                     # Get the data and decode it with base 64 decoder.
-                    #parts = payload.get('parts')[0]
                     data = payload['body']['data']
-                    #data = data.replace("-","+").replace("_","/")
                     decoded_data = base64.b64decode(data)
-        
-                    # Now, the data obtained is in lxml. So, we will parse 
-                    # it with BeautifulSoup library
-                    #soup = BeautifulSoup(decoded_data , "lxml") # may not need this, could just parde the decoded_data for the number
-                    #body = soup.body()
+    
         
                     auth_code = re.sub("\D", "", str(decoded_data))
 
@@ -122,10 +115,5 @@ class BCVPIssuerGetAuthCodeInterface():
 
                     return auth_code
 
-                    # Printing the subject, sender's email and message
-                    # print("Subject: ", subject)
-                    # print("From: ", sender)
-                    # print("Message: ", body)
-                    # print('\n')
             except:
                 raise

--- a/aries-mobile-tests/requirements.txt
+++ b/aries-mobile-tests/requirements.txt
@@ -12,3 +12,6 @@ psutil==5.7.2
 Appium-Python-Client
 qrcode[pil]~=6.1
 webdriver-manager==3.8.3
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

Remove bs4 import no longer needed. Add google api imports to requirements.