### PR TITLE
Fix for getting version element on settings page on iOS < 15

### DIFF
--- a/aries-mobile-tests/pageobjects/basepage.py
+++ b/aries-mobile-tests/pageobjects/basepage.py
@@ -52,7 +52,7 @@ class BasePage(object):
 
     def find_by(self, locator_tpl: tuple, timeout=20, wait_condition:WaitCondition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED):
         if locator_tpl[0] == MobileBy.ACCESSIBILITY_ID or locator_tpl[0] == AppiumBy.ACCESSIBILITY_ID:
-            return self.find_by_accessibility_id(locator_tpl[1], timeout)
+            return self.find_by_accessibility_id(locator_tpl[1], timeout, wait_condition)
         elif locator_tpl[0] == MobileBy.ID or locator_tpl[0] == AppiumBy.ID:
             return self.find_by_element_id(locator_tpl[1], timeout, wait_condition)
 
@@ -71,11 +71,11 @@ class BasePage(object):
             #return self.find_multiple_by_id(locator_tpl[1], timeout)
 
     # Locate by Accessibility id
-    def find_by_accessibility_id(self, locator, timeout=20):
+    def find_by_accessibility_id(self, locator, timeout=20, wait_condition:WaitCondition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED):
         try:
             # The location of a single element gets the location of a single element
             return WebDriverWait(self.driver, timeout).until(
-                EC.presence_of_element_located(
+                wait_condition(
                     (AppiumBy.ACCESSIBILITY_ID, locator))
             )
         except:

--- a/aries-mobile-tests/pageobjects/bc_wallet/settings.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/settings.py
@@ -16,7 +16,7 @@ class SettingsPage(BasePage):
     back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
     contacts_locator = "Contacts"
     version_locator = (AppiumBy.ID, "com.ariesbifold:id/Version")
-    version_aid_locator = (AppiumBy.ACCESSIBILITY_ID, "Version")
+    version_partial_aid_locator = (AppiumBy.ACCESSIBILITY_ID, "Version")
     intro_aid_locator = (AppiumBy.ACCESSIBILITY_ID, "Introduction to the app")
     intro_locator = (AppiumBy.ID, "com.ariesbifold:id/IntroductionToTheApp")
     developer_locator = (AppiumBy.ID, "com.ariesbifold:id/DeveloperOptions")
@@ -34,7 +34,15 @@ class SettingsPage(BasePage):
             raise Exception(f"App not on the {type(self)} page")
 
         self.scroll_to_bottom()
-        version_element = self.find_by(self.version_locator)
+        #version_element = self.find_by(self.version_locator)
+        if self.current_platform == "iOS" and self.driver.capabilities['platformVersion'] <= '15':
+            # Need to find the element py partial text or accessibility id for iOS 14 and lower
+            version_elements = self.driver.find_elements(AppiumBy.XPATH, "//*[contains(@label, '{}')]".format(self.version_partial_aid_locator[1]))
+            # take the last one on the page
+            version_element = version_elements[len(version_elements)-1]
+        else:
+            # this works for iOS 15+ and Android only
+            version_element = self.find_by(self.version_locator)
 
         # Click the version element 10 times to enable Developer Mode
         for i in range(10):


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR works around a problem with the BC wallet where the testID does not show for the version label on the settings page. It now gets the elements by partial text. 