### PR TITLE
fix for pervasive connection issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          directDomains: aries-mediator-agent-test.apps.silver.devops.gov.bc.ca
+          directDomains: aries-mediator-agent.vonx.io
 
       #    tunnelIdentifier: github-action-tunnel
       #    region: us-west-1

--- a/aries-mobile-tests/features/steps/bc_wallet/connect.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/connect.py
@@ -100,8 +100,6 @@ def step_impl(context):
         # One last check
         assert context.issuer.connected()
 
-    # Make sure the App has progressed from the connecting page as well. 
-    assert context.thisConnectingPage.wait_for_connection()
 
 @then('there is a connection between "{agent}" and Holder')
 def step_impl(context, agent):

--- a/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
@@ -31,6 +31,7 @@ def step_impl(context):
 def step_impl(context):
     context.issuer.send_credential()
 
+    assert context.thisConnectingPage.wait_for_connection()
     # context.thisCredentialOfferNotificationPage = CredentialOfferNotificationPage(context.driver)
     # assert context.thisCredentialOfferNotificationPage.on_this_page()
 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This BC WAllet Test PR changes the Sauce Connect tunnel to allow connections to the Prod Mediator instead of the Test Mediator. Switching to the Test env in the app doesn't switch to the test mediator, it remains on prod. 

There was also a new issue introduced in the previous PR that caused the send credential not to fire because the test code was waiting for the connecting image to disappear. That test code was moved to after the send credential. 