### PR TITLE
BCW CANdy test fix and add retry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
         env:
           LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           REGION: "us-west-1"
+          TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
         with:
           MOBILE_WALLET: "-w bc_wallet"
           ISSUER_AGENT: '-i "AATH;http://0.0.0.0:9020"'
@@ -131,6 +132,7 @@ jobs:
         env:
           LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           REGION: "us-west-1"
+          TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
         with:
           MOBILE_WALLET: "-w bc_wallet"
           ISSUER_AGENT: '-i "CANdy_UVP;https://openvp-candy-issuer-test.apps.silver.devops.gov.bc.ca/"'
@@ -157,6 +159,7 @@ jobs:
           BCSC_ACCOUNT_PASSWORD: ${{ secrets.BCSC_ACCOUNT_PASSWORD }}
           GOOGLE_API_TOKEN: ${{ secrets.GOOGLE_API_TOKEN }}
           GOOGLE_API_CREDENTIALS: ${{ secrets.GOOGLE_API_CREDENTIALS }}
+          TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
         with:
           MOBILE_WALLET: "-w bc_wallet"
           ISSUER_AGENT: '-i "BC_VP;https://bcvcpilot-issuer-admin-test.apps.silver.devops.gov.bc.ca"'

--- a/aries-mobile-tests/agent_factory/candy_uvp/pageobjects/issuing_credential_page.py
+++ b/aries-mobile-tests/agent_factory/candy_uvp/pageobjects/issuing_credential_page.py
@@ -16,7 +16,7 @@ class IssuingCredentialPage(WebBasePage):
 
 
     def on_this_page(self):     
-        return super().on_this_page(self.on_this_page_locator) 
+        return super().on_this_page(self.on_this_page_locator, timeout=20) 
 
     def connected(self):
         if self.on_this_page():

--- a/aries-mobile-tests/features/environment.py
+++ b/aries-mobile-tests/features/environment.py
@@ -51,8 +51,12 @@ def before_feature(context, feature):
     context.save_qr_code_on_creation = eval(context.config.userdata['save_qr_code_on_creation'])
 
     # retry failed tests 
+    try: 
+        test_retry_attempts = int(config('TEST_RETRY_ATTEMPTS_OVERRIDE'))
+    except:
+        test_retry_attempts = int(eval(context.config.userdata['test_retry_attempts']))
     for scenario in feature.scenarios:
-        patch_scenario_with_autoretry(scenario, max_attempts=eval(context.config.userdata['test_retry_attempts']))
+        patch_scenario_with_autoretry(scenario, max_attempts=test_retry_attempts)
 
 
 


### PR DESCRIPTION
Signed-off-by: Sheldon Regular <sheldon.regular@gmail.com>

This PR attempts to fix a find element issue with the CANdy UVP issuer but extending the timeout. 

This PR also adds functionality to the Mobile Test Harness to allow for retries of failed tests. The number of retries can be set in two ways. 
Set the following in the `behave.ini` file.
```
[behave.userdata]
test_retry_attempts=3
```
or by the override environment variable. 
`TEST_RETRY_ATTEMPTS_OVERRIDE: "2"`

With complex test environments, and separate environments for issuers, verifiers, mediators, etc, it isn't difficult to get into some timeout scenario when running a stack of test. The retry can be used to give a proper pass rate for wallets, instead of failing because of external environments. 
It is advisable to use the `TEST_RETRY_ATTEMPTS_OVERRIDE` env var in your scripts for setting retry attempts in your build/test pipeline. See main.yml in this PR for examples.