### PR TITLE
refactor getting BC Person invite URL

### DIFF
--- a/aries-mobile-tests/agent_factory/bc_vp/bc_vp_issuer_agent_interface.py
+++ b/aries-mobile-tests/agent_factory/bc_vp/bc_vp_issuer_agent_interface.py
@@ -1,6 +1,7 @@
 """
 Class for actual IDIM Verified Person Credetial issuer agent
 """
+from time import sleep
 from agent_factory.issuer_agent_interface import IssuerAgentInterface
 from sys import platform
 from decouple import config
@@ -30,6 +31,7 @@ class BC_VP_IssuerAgentInterface(IssuerAgentInterface):
     _authenticate_page: AuthenticatePage
     _invites_page: InvitesPage
     _invite_page: InvitePage
+    _invitation_url: str
 
     # Default schema and cred
     DEFAULT_CREDENTIAL_DATA = {
@@ -107,15 +109,25 @@ class BC_VP_IssuerAgentInterface(IssuerAgentInterface):
             self._invite_page.enter_program(
                 self.DEFAULT_CREDENTIAL_DATA["program"])
 
-        # TODO Temporarily comment the sending of the invite out until things are running smoothly, don't want to load up the service with invites.
         self._invites_page = self._invite_page.save()
         if not self._invites_page.on_this_page():
             raise Exception(
                 'Something is wrong, on the Invites Page after sending invite for the BC VP Issuer')
 
+
+        self._invitation_url= self._get_invitation_url()
+
         return True
-        # Could use the invite URL in on the invite details page of the issuer and generate a QR code to return here. 
-        # Fall back plan if using email is not viable.
+        
+    def _get_invitation_url(self):
+        # Get the invitation url from the invites page
+        self._invites_page.search(self.DEFAULT_CREDENTIAL_DATA["email"])
+        sleep(5)
+        self._invites_page.select_edit_invite(1)
+        return self._invites_page.get_invitation_url()
+    
+    def get_invitation_url(self):
+        return self._invitation_url
 
     def restart_issue_credential(self):
         # go to the issuer endpoint in the browser

--- a/aries-mobile-tests/agent_factory/bc_vp/pageobjects/invites_page.py
+++ b/aries-mobile-tests/agent_factory/bc_vp/pageobjects/invites_page.py
@@ -14,8 +14,11 @@ class InvitesPage(WebBasePage):
     new_invite_locator = (
         By.XPATH, '//*[@id="app"]/div/main/div/div/div/div/header/div/a')
     #search_locator = (By.CLASS_NAME, "v-input--selection-controls__ripple")
-    search_locator = (By.ID, "input-1277")
+    search_locator = (By.XPATH, "(//input[@type='text'])[1]")
     row_locator = (By.CLASS_NAME, "v-input--selection-controls__ripple")
+    edit_invite_locator = (By.XPATH, "(//button[@type='button'])[2]")
+    #invitation_url_locator = (By.XPATH, '(//a[contains(text(),'https://bcvcpilot-issuer-test.apps.silver.devops.gov.bc.ca')])[1]')
+    invitation_url_locator = (By.PARTIAL_LINK_TEXT, 'https://bcvcpilot-issuer-test.apps.silver.devops.gov.bc.ca')
 
     def on_this_page(self):
         return super().on_this_page(self.on_this_page_text_locator, timeout=1000)
@@ -33,3 +36,13 @@ class InvitesPage(WebBasePage):
             return InvitePage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")
+
+    def select_edit_invite(self, row: int):
+        if self.on_this_page():
+            self.find_by(self.edit_invite_locator).click()
+            return True
+        else:
+            raise Exception(f"App not on the {type(self)} page")
+
+    def get_invitation_url(self):
+        return self.find_by(self.invitation_url_locator).text

--- a/aries-mobile-tests/features/steps/bc_wallet/bcsc.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/bcsc.py
@@ -66,10 +66,11 @@ def step_impl(context):
     
 @given('the BCSC holder gets the invite QR Code from their email')
 def step_impl(context):
-    context.holderGetInviteInterface = BCVPHolderGetInviteInterface("http://www.gmail.com")
-    #sleep(5) # wait for email to come in with invitation.
-    assert context.holderGetInviteInterface.open_invitation_email()
-    assert context.holderGetInviteInterface.select_invitation_link()
+    #context.holderGetInviteInterface = BCVPHolderGetInviteInterface("http://www.gmail.com")
+    context.holderGetInviteInterface = BCVPHolderGetInviteInterface(context.issuer.get_invitation_url())
+
+    #assert context.holderGetInviteInterface.open_invitation_email()
+    #assert context.holderGetInviteInterface.select_invitation_link()
     qrcode =  context.holderGetInviteInterface.get_qr_code_invitation()
     context.device_service_handler.inject_qrcode(qrcode)
 


### PR DESCRIPTION
This PR changes the way we get the Invitation URL for the BC person credential tests. This way will be more reliable. It gets the invite URL directly from the issuer in the invite details page, instead of the holders email. 