### PR TITLE
BCW working revocation notification test

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -2,7 +2,7 @@
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/bcgov/bc-wallet-mobile/82
 # https://app.zenhub.com/workspaces/bc-wallet-6148e7423fe04b001444e2bd/issues/gh/bcgov/bc-wallet-mobile/231
 @Connect @bc_wallet @Story_76
-Feature: Connect to an Issuer/Scan QR Code for Credential
+Feature: Connections
 
 
    @T001-Connect @wip @critical @AcceptanceTest

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -299,7 +299,7 @@ Feature: Proof
       And the proof is unverified
 
 
-   @T011.1-Proof @normal @RevocationNotification @AcceptanceTest @Story_63 @wip
+   @T011.1-Proof @normal @RevocationNotification @AcceptanceTest @Story_63
    Scenario: Holder is notified that their credential has been revoked and is acknowledged
       Given the Holder has setup thier wallet
       And the Holder has selected to use biometrics to unlock BC Wallet

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -492,7 +492,8 @@ def step_impl(context):
 
 @then(u'the revocation notification is removed')
 def step_impl(context):
-    context.thisHomePage = context.thisNavBar.select_home()
+    context.thisHomePage = context.thisCredentialDetailsPage.select_back()
+    #context.thisHomePage = context.thisNavBar.select_home()
     assert context.thisHomePage.is_revocation_notification_present() == False
 
 


### PR DESCRIPTION
This is a BC Wallet related PR that adds a working revocation notification test scenario. The remaining revocation notification scenario set to WIP is blocked by a bug in BC Wallet.