### PR TITLE
Turn off retry attempts on failure for BCW tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           REGION: "us-west-1"
-          TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
+          #TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
         with:
           MOBILE_WALLET: "-w bc_wallet"
           ISSUER_AGENT: '-i "AATH;http://0.0.0.0:9020"'
@@ -132,7 +132,7 @@ jobs:
         env:
           LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           REGION: "us-west-1"
-          TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
+          #TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
         with:
           MOBILE_WALLET: "-w bc_wallet"
           ISSUER_AGENT: '-i "CANdy_UVP;https://openvp-candy-issuer-test.apps.silver.devops.gov.bc.ca/"'
@@ -160,7 +160,7 @@ jobs:
           BCSC_ACCOUNT_PASSWORD: ${{ secrets.BCSC_ACCOUNT_PASSWORD }}
           # GOOGLE_API_TOKEN: ${{ secrets.GOOGLE_API_TOKEN }}
           # GOOGLE_API_CREDENTIALS: ${{ secrets.GOOGLE_API_CREDENTIALS }}
-          TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
+          #TEST_RETRY_ATTEMPTS_OVERRIDE: "2"
         with:
           MOBILE_WALLET: "-w bc_wallet"
           ISSUER_AGENT: '-i "BC_VP;https://bcvcpilot-issuer-admin-test.apps.silver.devops.gov.bc.ca"'


### PR DESCRIPTION
This PR turns off the Test Failure Retry Attempts. The BC Wallet iOS full test run is taking up to 6 hours to run and is getting cancelled. This should cut the time down for the run so it doesn't get cancelled. When test failure are more infrequent, this can be turned back on.