### PR TITLE
Calibrate Tests to BCW build 318

### DIFF
--- a/aries-mobile-tests/agent_test_utils.py
+++ b/aries-mobile-tests/agent_test_utils.py
@@ -16,7 +16,7 @@ def get_qr_code_from_invitation(invitation_json, print_qr_code=False, save_qr_co
             f"Could not find an invitation url in invitation json {invitation_json}")
     invitation_url = invitation_json[invite_url_key]
 
-    qr = QRCode(border=20)
+    qr = QRCode(border=40)
     qr.add_data(invitation_url)
     qr.make()
     #img = qr.make_image(fill_color="red", back_color="#23dda0")

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -68,6 +68,8 @@ def step_impl(context):
     #assert context.thisInitializationPage.on_this_page()
     context.thisHomePage = context.thisInitializationPage.wait_until_initialized()
     context.thisNavBar = NavBar(context.driver)
+    if context.thisHomePage.welcome_to_bc_wallet_modal.is_displayed():
+        context.thisHomePage.welcome_to_bc_wallet_modal.select_dismiss()
     assert context.thisHomePage.on_this_page()
 
     # set the environment to TEST instead of PROD which is default as of build 575

--- a/aries-mobile-tests/pageobjects/bc_wallet/home.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/home.py
@@ -7,6 +7,7 @@ from pageobjects.bc_wallet.credential_offer import CredentialOfferPage
 from pageobjects.bc_wallet.proof_request import ProofRequestPage
 from pageobjects.bc_wallet.get_person_credential import GetPersonCredentialPage
 from pageobjects.bc_wallet.credential_details import CredentialDetailsPage
+from pageobjects.bc_wallet.welcome_to_bc_wallet import WelcomeToBCWalletModal
 from time import sleep
 
 
@@ -29,10 +30,18 @@ class HomePage(BasePage):
     settings_locator = (AppiumBy.ID, "com.ariesbifold:id/Settings")
     #get_bc_digital_id_locator = (AppiumBy.ID, "com.ariesbifold:id/GetBCID")
     get_bc_digital_id_locator = (AppiumBy.ID, "com.ariesbifold:id/ViewCustom")
+
+    # Modals and Alerts for Home page
+    welcome_to_bc_wallet_modal = WelcomeToBCWalletModal
     
+    def __init__(self, driver):
+        super().__init__(driver)
+        self.welcome_to_bc_wallet_modal = WelcomeToBCWalletModal(driver)
+
 
     def on_this_page(self):
         return super().on_this_page(self.on_this_page_text_locator)
+
 
     def select_credential_offer_notification(self):
         if super().on_this_page(self.on_this_page_notification_locator):

--- a/aries-mobile-tests/pageobjects/bc_wallet/welcome_to_bc_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/welcome_to_bc_wallet.py
@@ -1,0 +1,36 @@
+from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import BasePage
+from pageobjects.basepage import WaitCondition
+from pageobjects.bc_wallet.connecting import ConnectingPage
+from pageobjects.bc_wallet.settings import SettingsPage
+from pageobjects.bc_wallet.credential_offer import CredentialOfferPage
+from pageobjects.bc_wallet.proof_request import ProofRequestPage
+from pageobjects.bc_wallet.get_person_credential import GetPersonCredentialPage
+from pageobjects.bc_wallet.credential_details import CredentialDetailsPage
+from time import sleep
+
+
+class WelcomeToBCWalletModal(BasePage):
+    """Welcome to BC Wallet Modal page object"""
+
+    # Locators
+    on_this_page_text_locator = "Welcome to BC Wallet"
+    dismiss_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Dismiss")
+    use_app_guides_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Okay")
+    dont_use_app_guides_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Cancel")
+
+    def on_this_page(self):
+        return super().on_this_page(self.on_this_page_text_locator)
+    
+    def is_displayed(self):
+        return self.on_this_page()
+
+    def select_dismiss(self):
+        self.find_by(self.use_app_guides_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+
+    def select_dont_use_app_guides(self):
+        self.find_by(self.dont_use_app_guides_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+
+


### PR DESCRIPTION
This PR Accounts for the new In App Guide selection that shows on the Home page when the app starts. At this point it just dismisses the guide selector to continue with the tests. App Guide tests will come in the future. 