### PR TITLE
Fix Test harness BasePage iOS scroll_to_bottom

### DIFF
--- a/aries-mobile-tests/pageobjects/basepage.py
+++ b/aries-mobile-tests/pageobjects/basepage.py
@@ -6,6 +6,7 @@ from appium.webdriver.common.touch_action import TouchAction
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
+import xml.etree.ElementTree as ET
 
 class WaitCondition(Enum):
     ELEMENT_TO_BE_CLICKABLE = EC.element_to_be_clickable
@@ -187,6 +188,7 @@ class BasePage(object):
         # Scroll down the page until the bottom is reached
         while True:
             if self.current_platform == 'iOS':
+                before_source_ios = self.driver.page_source
                 self.driver.execute_script('mobile: scroll', {'direction': 'down'})
             else:
                 # Scroll for android takes an accessibility id, however it will scroll to the bottom looking for that id and if it doesn't exist,
@@ -197,9 +199,17 @@ class BasePage(object):
                     pass
 
             # Get the current scroll position
-            window_rect = self.driver.get_window_rect()
-            current_scroll_position = window_rect['y'] + screen_height
+            if self.current_platform == 'iOS':
+                after_source_ios = self.driver.page_source
+                # Parse the hierarchies using an XML parser
+                root = ET.fromstring(before_source_ios.encode('utf-8'))
+                new_root = ET.fromstring(after_source_ios.encode('utf-8'))
+                if ET.tostring(root) == ET.tostring(new_root):
+                    break
+            else:
+                window_rect = self.driver.get_window_rect()
+                current_scroll_position = window_rect['y'] + screen_height
 
-            # Check if the bottom of the page has been reached
-            if current_scroll_position >= screen_size['height']:
-                break
+                # Check if the bottom of the page has been reached
+                if current_scroll_position >= screen_size['height']:
+                    break

--- a/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
@@ -12,16 +12,16 @@ class CameraPrivacyPolicyPage(BasePage):
     # Locators
     on_this_page_text_locator = "Allow camera use"
     on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/AllowCameraUse")
-    #allow_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Allow")
-    allow_button_locator = (AppiumBy.ACCESSIBILITY_ID, "Allow")
+    allow_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Allow")
+    #allow_button_locator = (AppiumBy.ACCESSIBILITY_ID, "Allow")
     not_now_button_locator = (AppiumBy.ID, "com.ariesbifold:id/NotNow")
     system_allow_while_using_app =  (AppiumBy.ID, "com.android.permissioncontroller:id/permission_allow_foreground_only_button")
 
 
     def on_this_page(self):    
         #return super().on_this_page(self.on_this_page_locator) 
-        #return super().on_this_page(self.allow_button_locator)
-        return super().on_this_page(self.on_this_page_text_locator)
+        return super().on_this_page(self.allow_button_locator, timeout=5)
+        #return super().on_this_page(self.on_this_page_text_locator)
 
     def select_not_now(self):
         self.find_by(self.not_now_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()

--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
@@ -35,15 +35,9 @@ class CredentialOfferPage(BasePage):
 
     def select_accept(self, scroll=False):
         if self.on_this_page():
-            # if the credential has a lot of attributes it could need to scroll
             if scroll == True:
-                try:
-                    self.find_by(self.accept_locator).click()
-                except:
-                    self.scroll_to_element(self.decline_aid_locator[1])
-                    self.find_by(self.accept_locator).click()
-            else:
-                self.find_by(self.accept_locator).click()
+                self.scroll_to_bottom()
+            self.find_by(self.accept_locator).click()
             return CredentialOnTheWayPage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/proof_request.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/proof_request.py
@@ -34,7 +34,7 @@ class ProofRequestPage(BasePage):
             try:
                 self.find_by(self.share_locator).click()
             except:
-                self.scroll_to_element(self.share_aid_locator[1])
+                self.scroll_to_bottom()
                 self.find_by(self.share_locator).click()
             return SendingInformationSecurelyPage(self.driver)
         else:

--- a/aries-mobile-tests/pageobjects/bc_wallet/welcome_to_bc_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/welcome_to_bc_wallet.py
@@ -26,8 +26,10 @@ class WelcomeToBCWalletModal(BasePage):
         return self.on_this_page()
 
     def select_dismiss(self):
-        self.find_by(self.use_app_guides_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+        self.find_by(self.dismiss_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
+    def select_use_app_guides(self):
+        self.find_by(self.use_app_guides_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
     def select_dont_use_app_guides(self):
         self.find_by(self.dont_use_app_guides_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()


### PR DESCRIPTION
This PR fixes an iOS scroll_to_bottom issue where it would occasionally fail, this is because the x and y of the window rect would come back as zeros in some cases. Now with iOS it does comparison on page source at after a scroll to determine is it is at the bottom. 

This PR also contains a fix to the BCW app guides select dismiss button. 