### PR TITLE
BCW Dismiss app guide in dev mode

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -87,6 +87,8 @@ def step_impl(context, env):
     context.thisDeveloperSettingsPage.select_env(env)
     context.thisSettingsPage = context.thisDeveloperSettingsPage.select_back()
     context.thisSettingsPage.select_back()
+    if context.thisHomePage.welcome_to_bc_wallet_modal.is_displayed():
+        context.thisHomePage.welcome_to_bc_wallet_modal.select_dismiss()
     assert context.thisHomePage.on_this_page()
 
 


### PR DESCRIPTION
This PR is for BC Wallet. The latest build, when dev mode is toggled redisplays the app guide on the home screen. This update dismisses that modal to continue with testing. 