### PR TITLE
Fix BCW environment setting for security tests

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -57,8 +57,7 @@ Feature: Secure your Wallet
     And the User re-enters the PIN as "369369"
     And the User selects Create PIN
     And the User selects to use Biometrics
-    Then the User has successfully created a PIN
-    And they land on the Home screen
+    And they have access to the app
 
   @T005-Security @AcceptanceTest @ExceptionTest @normal
   Scenario: New User Sets Up PIN but PINs do not match

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -59,10 +59,19 @@ def step_impl(context):
     context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
     context.device_service_handler.biometrics_authenticate(True)
 
+@then('they have access to the app')
+def step_impl(context):
+    # The Home page will not show until the initialization page is done. 
+    #assert context.thisInitializationPage.on_this_page()
+    context.thisHomePage = context.thisInitializationPage.wait_until_initialized()
+    if context.thisHomePage.welcome_to_bc_wallet_modal.is_displayed():
+        #context.thisHomePage.welcome_to_bc_wallet_modal.select_dismiss()
+        assert True
+    else:
+        assert context.thisHomePage.on_this_page()
+
 @then('they land on the Home screen')
 @when('initialization ends (failing silently)')
-@then('they have access to the app')
-@then('the User has successfully created a PIN')
 def step_impl(context):
     # The Home page will not show until the initialization page is done. 
     #assert context.thisInitializationPage.on_this_page()


### PR DESCRIPTION
The PR changes the ending of the security tests for BC Wallet which use to go ahead and change the environment to the test env. There is no need to do that in these tests, and saves minutes off of each test to remove it. 