### PR TITLE
BCW stop Scrolling for iOS

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_offer.py
@@ -35,7 +35,7 @@ class CredentialOfferPage(BasePage):
 
     def select_accept(self, scroll=False):
         if self.on_this_page():
-            if scroll == True:
+            if scroll == True and self.current_platform == 'Android':
                 self.scroll_to_bottom()
             self.find_by(self.accept_locator).click()
             return CredentialOnTheWayPage(self.driver)

--- a/aries-mobile-tests/pageobjects/bc_wallet/proof_request.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/proof_request.py
@@ -34,7 +34,8 @@ class ProofRequestPage(BasePage):
             try:
                 self.find_by(self.share_locator).click()
             except:
-                self.scroll_to_bottom()
+                if self.current_platform == 'Android':
+                    self.scroll_to_bottom()
                 self.find_by(self.share_locator).click()
             return SendingInformationSecurelyPage(self.driver)
         else:


### PR DESCRIPTION
This PR stops BC Wallet scrolling for iOS when a cred offer or proof request comes in. With large credentials it takes a long time to scroll. iOS will find the element anyway even if it is not in the viewport, unlike Android where scrolling has to happen. 