### PR TITLE
BCW fix remove contact test to select testID

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -66,7 +66,6 @@ Feature: Connections
    Scenario Outline: Remove an Issuer contact where no credentials are issued from that contact
       Given the holder is connected to an Issuer
       And there are <no_credentials> issued by this Contact in the holders wallet
-      And the holder is viewing that Contact's details
       When the holder Removes this Contact
       And the holder reviews more details on removing Contacts
          | details                                                            |

--- a/aries-mobile-tests/pageobjects/bc_wallet/contact.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/contact.py
@@ -12,7 +12,8 @@ class ContactPage(BasePage):
 
     # Locator
     #on_this_page_text_locator = "Contacts"
-    contact_locator = (AppiumBy.ACCESSIBILITY_ID, "Settings")
+    contact_locator = (AppiumBy.ID, "com.ariesbifold:id/Settings")
+    
 
     def on_this_page(self):     
         return super().on_this_page(self.contact_locator) 


### PR DESCRIPTION
This PR is for the BC Wallet Remove Contact test scenarios. The info/settings element for contacts has a new TestID and a changed accessibility label. 