### PR TITLE
BCW Speed up Camera Policy Allow

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/connect.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/connect.py
@@ -55,7 +55,7 @@ def step_impl(context, agent):
     if context.driver.capabilities['platformName'] == 'iOS':
         context.thisCameraPrivacyPolicyPage = CameraPrivacyPolicyPage(context.driver)
         if context.thisCameraPrivacyPolicyPage.on_this_page():
-            context.thisCameraPrivacyPolicyPage.select_okay()
+            context.thisCameraPrivacyPolicyPage.select_allow()
 
 
 @when('the Holder is taken to the Connecting Screen/modal')

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -412,7 +412,7 @@ def step_impl(context):
         context.thisCameraPrivacyPolicyPage = CameraPrivacyPolicyPage(
             context.driver)
         if context.thisCameraPrivacyPolicyPage.on_this_page():
-            context.thisCameraPrivacyPolicyPage.select_okay()
+            context.thisCameraPrivacyPolicyPage.select_allow()
 
 
 @given('the user has a connectionless proof request for access to PCTF Chat')

--- a/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
@@ -19,16 +19,29 @@ class CameraPrivacyPolicyPage(BasePage):
 
 
     def on_this_page(self):    
-        #return super().on_this_page(self.on_this_page_locator) 
-        return super().on_this_page(self.allow_button_locator, timeout=5)
-        #return super().on_this_page(self.on_this_page_text_locator)
+        # 8 sec
+        return super().on_this_page(self.on_this_page_locator) 
+        # 14 sec
+        #return super().on_this_page(self.allow_button_locator, timeout=5)
+        # 19 sec
+        return super().on_this_page(self.on_this_page_text_locator)
 
     def select_not_now(self):
         self.find_by(self.not_now_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+        #self.find_by(self.not_now_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        # 26 sec
+        #self.find_by(self.not_now_button_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED).click()
         return True
 
-    def select_okay(self):
-        self.find_by(self.allow_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+    def select_allow(self):
+        # 26 sec
+        #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+        # 19 sec
+        self.find_by(self.allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        # 28 sec
+        #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED).click()
+        # 22 sec
+        #self.find_by((AppiumBy.ACCESSIBILITY_ID, "Allow"), wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
         if self.driver.capabilities['platformName'] == 'Android':
             self.select_system_allow_while_using_app()
         return True


### PR DESCRIPTION
This PR is for BC wallet tests. The Camera Policy page takes a long time to select Allow on iOS. Used the fastest find by routine (but still fairly long), hopefully that will be good enough. Revisit if not. 