### PR TITLE
pin selenium at 4.9.0

### DIFF
--- a/aries-mobile-tests/requirements.txt
+++ b/aries-mobile-tests/requirements.txt
@@ -5,7 +5,7 @@ browserstack-local==1.2.2
 SauceClient
 paver==1.3.4
 #selenium==3.141.0
-selenium
+selenium==4.9.0
 psutil==5.7.2
 #Appium-Python-Client==0.52;python_version < '3.0'
 #Appium-Python-Client==1.0.2;python_version >= '3.0'


### PR DESCRIPTION
This PR sets the selenium version to 4.9.0 since 4.9.1 caused driver not to instantiate in the test harness. This can be removed when 4.9.1 is fixed. 