### PR TITLE
Anchor Appium at 2.9.0

### DIFF
--- a/aries-mobile-tests/requirements.txt
+++ b/aries-mobile-tests/requirements.txt
@@ -9,7 +9,7 @@ selenium==4.9.0
 psutil==5.7.2
 #Appium-Python-Client==0.52;python_version < '3.0'
 #Appium-Python-Client==1.0.2;python_version >= '3.0'
-Appium-Python-Client
+Appium-Python-Client==2.9.0
 qrcode[pil]~=6.1
 webdriver-manager==3.8.3
 google-api-python-client


### PR DESCRIPTION
Android test may fail with 2.9.1+ of the Appium Python Client. The BCW tests that restarted the app, gave a message Unknown mobile command "activateApp". Pinning at 2.9.0 resolved this issue. May be able unpin when this issue is fixed in the library. 