### PR TITLE
fix LEDGER setting for starting AATH Agents in Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,12 +60,14 @@ jobs:
         if: ${{ matrix.mobile-platform=='-p iOS' && !contains(matrix.report-project,'candy-uvp-pcft-chat') }}
         uses: ./.github/workflows/run-aath-agents
         with:
+          LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           USE_NGROK: ""
 
       - name: run-aath-agents-ngrok
         if: ${{ matrix.mobile-platform=='-p Android' && contains(matrix.report-project,'candy-uvp-pcft-chat') }}
         uses: ./.github/workflows/run-aath-agents
         with:
+          LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           USE_NGROK: "-n"
 
       - name: run-aath-verifier-agent


### PR DESCRIPTION
The PR adds the LEDGER URL when starting agents. With the recent change of being able to add GENESIS URL, LEDGER URL is now optional without a default. 