### PR TITLE
updated workflow to correctly start agents with correct ledgers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,12 +60,14 @@ jobs:
         if: ${{ matrix.mobile-platform=='-p iOS' && !contains(matrix.report-project,'candy-uvp-pcft-chat') }}
         uses: ./.github/workflows/run-aath-agents
         with:
+          LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           USE_NGROK: ""
 
       - name: run-aath-agents-ngrok
-        if: ${{ matrix.mobile-platform=='-p Android' && contains(matrix.report-project,'candy-uvp-pcft-chat') }}
+        if: ${{ matrix.mobile-platform=='-p Android' && !contains(matrix.report-project,'candy-uvp-pcft-chat') }}
         uses: ./.github/workflows/run-aath-agents
         with:
+          LEDGER_URL_CONFIG: "http://test.bcovrin.vonx.io"
           USE_NGROK: "-n"
 
       - name: run-aath-verifier-agent
@@ -78,7 +80,7 @@ jobs:
           USE_NGROK: ""
 
       - name: run-aath-verifier-agent-ngrok
-        if: ${{ matrix.mobile-platform=='-p Android' && !contains(matrix.report-project,'candy-uvp-pcft-chat') }}
+        if: ${{ matrix.mobile-platform=='-p Android' && contains(matrix.report-project,'candy-uvp-pcft-chat') }}
         uses: ./.github/workflows/run-aath-agents
         with:
           TEST_AGENTS: "-b acapy-main"

--- a/.github/workflows/run-aath-agents/action.yml
+++ b/.github/workflows/run-aath-agents/action.yml
@@ -39,7 +39,14 @@ runs:
       shell: bash
       working-directory: aries-agent-test-harness
     - name: run-aath-agents
-      run: LEDGER_URL_CONFIG=${{inputs.LEDGER_URL_CONFIG}} TAILS_SERVER_URL_CONFIG=${{inputs.TAILS_SERVER_URL_CONFIG}} AGENT_CONFIG_FILE=${{inputs.AGENT_CONFIG_FILE}} ./manage start ${{inputs.TEST_AGENTS}} ${{inputs.USE_NGROK}}
+      run: |
+        if [[ -n "${{ inputs.LEDGER_URL_CONFIG }}" ]]; then
+          LEDGER_URL_CONFIG=${{inputs.LEDGER_URL_CONFIG}} TAILS_SERVER_URL_CONFIG=${{inputs.TAILS_SERVER_URL_CONFIG}} AGENT_CONFIG_FILE=${{inputs.AGENT_CONFIG_FILE}} ./manage start ${{inputs.TEST_AGENTS}} ${{inputs.USE_NGROK}}
+        elif [[ -n "${{ inputs.GENESIS_URL }}" ]]; then
+          GENESIS_URL=${{ inputs.GENESIS_URL }} TAILS_SERVER_URL_CONFIG=${{ inputs.TAILS_SERVER_URL_CONFIG }} AGENT_CONFIG_FILE=${{ inputs.AGENT_CONFIG_FILE }} ./manage start ${{ inputs.TEST_AGENTS }} ${{ inputs.USE_NGROK }}
+        else
+          echo "Neither LEDGER_URL_CONFIG nor GENESIS_URL provided."
+        fi
       shell: bash
       working-directory: aries-agent-test-harness
     - name: shut-down-uniresolver


### PR DESCRIPTION
This PR updates the workflows to properly set LEDGER URL or GENESIS URL depending on what is passed to start the test agents with.