### PR TITLE
BCW fix message checkon remove contact

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/contact_remove_from_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/contact_remove_from_wallet.py
@@ -10,7 +10,7 @@ class ContactRemoveFromWalletPage(BasePage):
     """Remove Contact from wallet page object"""
 
     # Locator
-    on_this_page_text_locator = "Remove this contact"
+    on_this_page_text_locator = "Remove this Contact"
     remove_contact_locator = (AppiumBy.ID, "com.ariesbifold:id/ConfirmRemoveButton")
 
     def on_this_page(self):     


### PR DESCRIPTION
This PR just changes the message check for the BC Wallet remove contact test to the proper case. 