### PR TITLE
Fix BCW revocation notification test post 969 updates

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_details.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_details.py
@@ -12,8 +12,8 @@ class CredentialDetailsPage(BasePage):
     # Locators
     on_this_page_text_locator = "Credential Details"
     #back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
-    back_locator = (AppiumBy.ACCESSIBILITY_ID, "Tab Stack, back")
-    revocation_dismiss_locator = (AppiumBy.ID, "com.ariesbifold:id/Okay")
+    back_locator = (AppiumBy.ACCESSIBILITY_ID, "Back")
+    revocation_dismiss_locator = (AppiumBy.ID, "com.ariesbifold:id/Dismiss")
     revocation_message_locator = (AppiumBy.ID, "com.ariesbifold:id/BodyText")
     revocation_status_locator = (AppiumBy.ID, "com.ariesbifold:id/RevokedDate")
     revocation_info_locator = (AppiumBy.ID, "com.ariesbifold:id/RevocationInfo")

--- a/aries-mobile-tests/pageobjects/bc_wallet/home.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/home.py
@@ -59,15 +59,15 @@ class HomePage(BasePage):
 
     def select_revocation_notification(self):
         if super().on_this_page(self.on_this_page_revocation_notification_locator, timeout=20):
-            if self.current_platform == "iOS" and self.driver.capabilities['platformVersion'] <= '15':
-                #self.find_by(self.view_revocation_notification_button_aid_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
-                # Need to find the element py partial text or accessibility id for iOS 14 and lower
-                view_notification_elements = self.driver.find_elements(AppiumBy.XPATH, "//*[contains(@label, '{}')]".format(self.view_revocation_notification_button_aid_locator[1]))
-                # take the last one on the page
-                view_notification_element = view_notification_elements[len(view_notification_elements)-5]
-                view_notification_element.click()
-            else:
-                self.find_by(self.view_revocation_notification_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            # if self.current_platform == "iOS" and self.driver.capabilities['platformVersion'] <= '15':
+            #     #self.find_by(self.view_revocation_notification_button_aid_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            #     # Need to find the element py partial text or accessibility id for iOS 14 and lower
+            #     view_notification_elements = self.driver.find_elements(AppiumBy.XPATH, "//*[contains(@label, '{}')]".format(self.view_revocation_notification_button_aid_locator[1]))
+            #     # take the last one on the page
+            #     view_notification_element = view_notification_elements[len(view_notification_elements)-5]
+            #     view_notification_element.click()
+            # else:
+            self.find_by(self.view_revocation_notification_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
             # return a new page object for the Revocation page
             return CredentialDetailsPage(self.driver)

--- a/aries-mobile-tests/sl_android_config.json
+++ b/aries-mobile-tests/sl_android_config.json
@@ -4,8 +4,6 @@
         "build": "build-1",
         "platformName": "Android",
         "app":"storage:filename=app-release.apk",
-        "deviceName":"Samsung.*",
-        "platformVersion":"11",
         "sessionCreationRetry" : "3",
         "sauceLabsImageInjectionEnabled": true,
         "autoGrantPermissions": true,

--- a/aries-mobile-tests/sl_ios_config.json
+++ b/aries-mobile-tests/sl_ios_config.json
@@ -4,7 +4,6 @@
         "build": "build-1",
         "platformName": "iOS",
         "app": "storage:filename=AriesBifold-76.ipa",
-        "deviceName": "iPhone.*",
         "sessionCreationRetry": "3",
         "sauceLabsImageInjectionEnabled": true,
         "autoAcceptAlerts": true,


### PR DESCRIPTION
This PR calibrates the tests to fixes to Credential Revocation features in BC Wallet, in part to BCW issue 969. This now should pass on Android, however since this 969 update iOS is not finding the Dismiss TestID on the Credential Details page so it should fail on iOS. See https://github.com/bcgov/bc-wallet-mobile/issues/951

This PR also includes the opening up of iOS/Android devices including tablets, along with lifting some older platform version restrictions to see what happens in the regression tests. 