### PR TITLE
Align BCW tests to new scan/connection flow

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/credential_offer.feature
+++ b/aries-mobile-tests/features/bc_wallet/credential_offer.feature
@@ -16,6 +16,7 @@ Feature: Offer a Credential
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       When the Holder receives a Non-Revocable credential offer
+      And the holder opens the credential offer
       Then holder is brought to the credential offer screen
       And they can view the contents of the credential
          | issuer_agent_type | who         | cred_type    | attributes           | values                  |
@@ -31,7 +32,8 @@ Feature: Offer a Credential
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer
-      When they select Accept
+      When the holder opens the credential offer
+      And they select Accept
       And the holder is informed that their credential is on the way with an indication of loading
       And once the credential arrives they are informed that the Credential is added to your wallet
       And they select Done
@@ -48,7 +50,8 @@ Feature: Offer a Credential
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer of <credential>
-      When they select Accept
+      When the holder opens the credential offer
+      And they select Accept
       And the holder is informed that their credential is on the way with an indication of loading
       And once the credential arrives they are informed that the Credential is added to your wallet
       And they select Done
@@ -70,7 +73,8 @@ Feature: Offer a Credential
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer
-      When they select Decline
+      When the holder opens the credential offer
+      And they select Decline
       Then they are brought to the list of credentials
       And a temporary notification will appear that informs the holder of the declined action
       And the credential declined is not in the list

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -22,6 +22,7 @@ Feature: Proof
       And the Holder is taken to the Connecting Screen/modal
       And the Connecting completes successfully
       And the Holder receives a proof request
+      And the holder opens the proof request
       Then holder is brought to the proof request
       And they can view the contents of the proof request
          | verifier_agent_type | who        | attributes | values  |

--- a/aries-mobile-tests/features/steps/bc_wallet/connect.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/connect.py
@@ -7,6 +7,7 @@ from pageobjects.bc_wallet.navbar import NavBar
 from behave import given, when, then
 import json
 from time import sleep
+import logging
 
 
 # Local Imports
@@ -16,6 +17,7 @@ from agent_test_utils import get_qr_code_from_invitation
 from pageobjects.bc_wallet.connecting import ConnectingPage
 from pageobjects.bc_wallet.home import HomePage
 from pageobjects.bc_wallet.camera_privacy_policy import CameraPrivacyPolicyPage
+from pageobjects.bc_wallet.contact import ContactPage
 
 @given('a PIN has been set up with "{pin}"')
 def step_impl(context, pin):
@@ -60,17 +62,15 @@ def step_impl(context, agent):
 
 @when('the Holder is taken to the Connecting Screen/modal')
 def step_impl(context):
-    # The connecting screen is temporary. 
-    # What if the connecting screen goes away too fast before this next line runs? Maybe check at home?
-    assert context.thisConnectingPage.on_this_page()
-    # context.connecting_is_done = False
-    # if context.thisConnectingPage.on_this_page():
-    #     assert True
-    # else:
-    #     # We are probably already on the home screen
-    #     # TDOD as of build 164 this isn't needed. It seems the page doesn't automatically go to the home screen after a while
-    #     assert context.thisHomePage.on_this_page()
-    #     context.connecting_is_done = True
+    # The connecting screen is very temporary. 
+    # Do a soft assert on the connection screen. If we are not on it then we are probably already on the contacts chat screen
+    try:
+        assert context.thisConnectingPage.on_this_page()
+    except AssertionError:
+        logging.info('Soft Assertion failed. Not on the connecting screen. Probably already connected, and on Chat for the contact.')
+
+    # TODO What if the connection never completes? We need to handle this.
+
 
 @given('the Connecting completes successfully')
 @when('the Connecting completes successfully')
@@ -102,6 +102,10 @@ def step_impl(context):
         # One last check
         assert context.issuer.connected()
 
+    # if connected the holder should be on the contact page
+    # TODO that is unless there is a Goal Code
+    context.thisContactPage = ContactPage(context.driver)
+
 
 @then('there is a connection between "{agent}" and Holder')
 def step_impl(context, agent):
@@ -113,7 +117,9 @@ def step_impl(context, agent):
         assert context.verifier.connected()
     else:
         raise Exception(f"Invalid agent type: {agent}")
-    #assert context.issuer.connected()
+    
+    # If connected the contact should be on the contact chat page
+    assert context.thisContactPage.on_this_page()
     
     
 

--- a/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
@@ -31,10 +31,19 @@ def step_impl(context):
 def step_impl(context):
     context.issuer.send_credential()
 
+    # May not need this assert anymore with the new connection/scan flow.
     assert context.thisConnectingPage.wait_for_connection()
     # context.thisCredentialOfferNotificationPage = CredentialOfferNotificationPage(context.driver)
     # assert context.thisCredentialOfferNotificationPage.on_this_page()
 
+    # Check the Contact page for the credential offer
+    assert context.thisContactPage.wait_for_credential_offer()
+
+
+@when('the holder opens the credential offer')
+def step_impl(context):
+    # Select the credential offer
+    context.thisCredentialOfferPage = context.thisContactPage.select_open_credential_offer()
 
 
 @given('the Holder receives a credential offer of {credential}')
@@ -144,6 +153,7 @@ def step_impl(context):
 def step_impl(context):
     context.execute_steps(f'''
         When the Holder receives a Non-Revocable credential offer
+        And the holder opens the credential offer
         Then holder is brought to the credential offer screen
     ''')
 
@@ -162,6 +172,7 @@ def step_impl(context, credential, revocation=None):
         ''')
 
     context.execute_steps(f'''
+            When the holder opens the credential offer
             Then holder is brought to the credential offer screen
         ''')
 

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -123,10 +123,16 @@ def step_impl(context, proof=None, interval=None):
             print("FileNotFoundError: features/data/" + proof.lower() + ".json")
 
 
+@when('the holder opens the proof request')
+def step_impl(context):
+    # Select the credential offer
+    context.thisProofRequestPage = context.thisContactPage.select_open_proof_request()
+
+
 @then('holder is brought to the proof request')
 def step_impl(context):
 
-    context.thisProofRequestPage = ProofRequestPage(context.driver)
+    #context.thisProofRequestPage = ProofRequestPage(context.driver)
     assert context.thisProofRequestPage.on_this_page()
 
 
@@ -147,8 +153,7 @@ def step_impl(context):
 
 @then('they Confirm the decline')
 def step_impl(context):
-    context.thisProofRequestDeclinedPage = context.thisAreYouSureDeclineProofRequest.select_confirm()
-    context.thisHomePage = context.thisProofRequestDeclinedPage.select_done()
+    context.thisHomePage = context.thisAreYouSureDeclineProofRequest.select_confirm()
 
 
 @then('they can view the contents of the proof request')
@@ -237,6 +242,7 @@ def step_impl(context):
             And the Holder is taken to the Connecting Screen/modal
             And the Connecting completes successfully
             And the Holder receives a proof request
+            And the holder opens the proof request
             Then holder is brought to the proof request
         ''')
 
@@ -269,6 +275,7 @@ def step_impl(context, proof, interval=None):
         ''')
 
     context.execute_steps('''
+        When the holder opens the proof request
         Then holder is brought to the proof request
     ''')
 

--- a/aries-mobile-tests/pageobjects/bc_wallet/are_you_sure_decline_proof_request.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/are_you_sure_decline_proof_request.py
@@ -3,7 +3,6 @@ from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.proof_request_declined import ProofRequestDeclinedPage
 
 
 # These classes can inherit from a BasePage to do common setup and functions
@@ -23,7 +22,8 @@ class AreYouSureDeclineProofRequestPage(BasePage):
     def select_confirm(self):
         if self.on_this_page():
             self.find_by(self.confirm_locator).click()
-            return ProofRequestDeclinedPage(self.driver)
+            from pageobjects.bc_wallet.home import HomePage
+            return HomePage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")
 

--- a/aries-mobile-tests/pageobjects/bc_wallet/contact.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/contact.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
@@ -5,6 +6,9 @@ from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.basepage import WaitCondition
 from pageobjects.bc_wallet.contact_details import ContactDetailsPage
+from pageobjects.bc_wallet.credential_offer import CredentialOfferPage
+from pageobjects.bc_wallet.proof_request import ProofRequestPage
+from selenium.common.exceptions import TimeoutException
 
 
 class ContactPage(BasePage):
@@ -13,7 +17,16 @@ class ContactPage(BasePage):
     # Locator
     #on_this_page_text_locator = "Contacts"
     contact_locator = (AppiumBy.ID, "com.ariesbifold:id/Settings")
-    
+    chat_box_locator = (AppiumBy.ID, "com.ariesbifold:id/ChatBox")
+    send_message_locator = (AppiumBy.ID, "com.ariesbifold:id/SendMessage")
+    #credential_offer_message_locator = (AppiumBy.ID, "com.ariesbifold:id/MessageText")
+    #credential_offer_message_locator = (AppiumBy.ANDROID_UIAUTOMATOR, "sent a credential offer"
+    #proof_request_message_locator = (AppiumBy.ID, "com.ariesbifold:id/MessageText")
+    #proof_request_message_locator = (AppiumBy.ACCESSIBILITY_ID, "sent a proof request")
+    credential_offer_message_locator = (AppiumBy.XPATH, '//*[contains(@accessibilityId, "sent a credential offer")]')
+    proof_request_message_locator = (AppiumBy.XPATH, '//*[contains(@accessibilityId, "sent a proof request")]')
+    open_credential_offer_locator = (AppiumBy.ID, "com.ariesbifold:id/OpenItem")
+    open_proof_request_locator = (AppiumBy.ID, "com.ariesbifold:id/OpenItem")
 
     def on_this_page(self):     
         return super().on_this_page(self.contact_locator) 
@@ -27,4 +40,46 @@ class ContactPage(BasePage):
         else:
             raise Exception(f"App not on the {type(self)}") 
 
+    def select_open_credential_offer(self):
+        if self.on_this_page():
+            self.find_by(self.open_credential_offer_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            return CredentialOfferPage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)}")
+    
+    def select_open_proof_request(self):
+        if self.on_this_page():
+            self.find_by(self.open_proof_request_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            return ProofRequestPage(self.driver)
+        else:
+            raise Exception(f"App not on the {type(self)}")
 
+    def wait_for_credential_offer(self, timeout=300):
+        # Set up logging
+        logger = logging.getLogger(__name__)
+
+        # Wait for the credential offer to appear
+        try:
+            self.find_by(self.credential_offer_message_locator, timeout, WaitCondition.PRESENCE_OF_ELEMENT_LOCATED)
+            logger.debug("Credential Offer Appeared")
+        except TimeoutException:
+            logger.error(f"Credential Offer taking longer than expected. Timing out at {timeout} seconds.")
+            raise
+
+        # Return the True the credential offer appeared
+        return True
+
+    def wait_for_proof_request(self, timeout=300):
+        # Set up logging
+        logger = logging.getLogger(__name__)
+
+        # Wait for the proof request to appear
+        try:
+            self.find_by(self.proof_request_message_locator, timeout, WaitCondition.PRESENCE_OF_ELEMENT_LOCATED)
+            logger.debug("Proof Request Appeared")
+        except TimeoutException:
+            logger.error(f"Proof Request taking longer than expected. Timing out at {timeout} seconds.")
+            raise
+
+        # Return the True the proof request appeared
+        return True

--- a/aries-mobile-tests/pageobjects/bc_wallet/proof_request_declined.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/proof_request_declined.py
@@ -7,6 +7,7 @@ from pageobjects.basepage import BasePage
 # These classes can inherit from a BasePage to do common setup and functions
 class ProofRequestDeclinedPage(BasePage):
     """Proof Request Declined page object"""
+    """ DEPREICATED  - Saving it incase this page comes back """ 
     
     # Locators
     on_this_page_text_locator = "Proof request declined"


### PR DESCRIPTION
This PR updates the BC Wallet test flows to the new Scan and Connection workflow in the app. 

It also sneaks in a fix to another test that was still looking at the decline proof request done screen.