### PR TITLE
streamline the iOS scroll to bottom

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/developer_settings.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/developer_settings.py
@@ -12,7 +12,8 @@ class DeveloperSettingsPage(BasePage):
     # Locators
     on_this_page_text_locator = "Developer"
     back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
-    environment_locator = (AppiumBy.ID, "com.ariesbifold:id/environment")
+    environment_locator_ios = (AppiumBy.ID, "com.ariesbifold:id/environment")
+    environment_locator = (AppiumBy.ACCESSIBILITY_ID, "Environment")
     production_locator = (AppiumBy.ID, "com.ariesbifold:id/production")
     development_locator = (AppiumBy.ID, "com.ariesbifold:id/development")
     test_locator = (AppiumBy.ID, "com.ariesbifold:id/test")
@@ -22,7 +23,10 @@ class DeveloperSettingsPage(BasePage):
 
     def select_env(self, env):
         if self.on_this_page():
-            self.find_by(self.environment_locator).click()
+            if self.current_platform == "iOS":
+                self.find_by(self.environment_locator_ios).click()
+            else:
+                self.find_by(self.environment_locator).click()
             if env == 'Production':
                 self.find_by(self.production_locator).click()
             elif env == 'Development':

--- a/aries-mobile-tests/pageobjects/bc_wallet/settings.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/settings.py
@@ -34,8 +34,11 @@ class SettingsPage(BasePage):
         if not self.on_this_page():
             raise Exception(f"App not on the {type(self)} page")
 
+        # if self.current_platform == "iOS":
+        #     self.scroll_to_element(self.version_locator)
+        # else:
         self.scroll_to_bottom()
-        #version_element = self.find_by(self.version_locator)
+
         if self.current_platform == "iOS" and self.driver.capabilities['platformVersion'] <= '15':
             # Need to find the element py partial text or accessibility id for iOS 14 and lower
             version_elements = self.driver.find_elements(AppiumBy.XPATH, "//*[contains(@label, '{}')]".format(self.version_partial_aid_locator[1]))


### PR DESCRIPTION
This PR streamlines the scroll to bottom function for iOS. Something changed in the infrastructure that now returns the different page xml even if it looks the same, we were using xml compare to determine if we were at the bottom of the page. This was causing some BC Wallet tests using this scroll to continue the scroll attempt to over an hour. The routine now checks for the last app element in the viewport and compares it to the before scroll last app element. 