### PR TITLE
Handle BCW scan failures better

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/connect.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/connect.py
@@ -3,6 +3,7 @@
 # 
 # -----------------------------------------------------------
 
+from pageobjects.bc_wallet.scan import ScanPage
 from pageobjects.bc_wallet.navbar import NavBar
 from behave import given, when, then
 import json
@@ -45,9 +46,9 @@ def step_impl(context, agent):
         qr_code_border = 40
 
     if agent == "issuer":
-        qrimage = context.issuer.create_invitation(print_qrcode=context.print_qr_code_on_creation, save_qrcode=context.save_qr_code_on_creation)
+        qrimage = context.issuer.create_invitation(print_qrcode=context.print_qr_code_on_creation, save_qrcode=context.save_qr_code_on_creation, qr_code_border=qr_code_border)
     elif agent == "verifier":
-        qrimage = context.verifier.create_invitation(print_qrcode=context.print_qr_code_on_creation, save_qrcode=context.save_qr_code_on_creation)
+        qrimage = context.verifier.create_invitation(print_qrcode=context.print_qr_code_on_creation, save_qrcode=context.save_qr_code_on_creation, qr_code_border=qr_code_border)
     else:
         raise Exception(f"Invalid agent type: {agent}")
 
@@ -67,6 +68,27 @@ def step_impl(context, agent):
         else:
             # soft assert that the camera privacy policy page was not displayed
             logging.info('Soft Assertion failed. Not on the Camera Privacy Policy Page. MAy cause preceeding connection steps to fail')
+
+    # It is possible that the QR code scan page could have an error displayed like invalid QR code, or at times displays
+    # no message and just sits there waiting, like there is no qr code to scan. Check to see if there is an error message and if so,
+    # close the scan window and scan again.
+    if hasattr(context, 'thisQRCodeScanPage') == False:
+        context.thisQRCodeScanPage = ScanPage(context.driver)
+    if context.thisQRCodeScanPage.on_this_page():
+        sleep(5)
+        if "Invalid QR code" in context.thisQRCodeScanPage.get_page_source():
+            # log the issue and close the scan window and scan again
+            logging.info("Invalid QR code error on scan page, closing and scanning again")
+        else:
+            # we are on the page but no error yet check one more time then close and scan again
+            logging.info("There might be a problem scanning the QR Code, attemting closing and scanning again")
+        # Make sure we are still scanning if not we have moved on. 
+        # This seems inefficent to check again since we just did 5 seconds ago, but it is possible that after the 5 seconds the QR code may have scanned and we moved on.
+        # TODO Think of a better way to do this. 
+        if context.thisQRCodeScanPage.on_this_page():
+            context.thisQRCodeScanPage.select_close()
+            context.device_service_handler.inject_qrcode(qrimage)
+            context.thisConnectingPage = context.thisNavBar.select_scan()
 
 
 @when('the Holder is taken to the Connecting Screen/modal')

--- a/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
@@ -205,7 +205,9 @@ def step_impl(context):
     try:
         context.thisCredentialAddedPage = context.thisCredentialOnTheWayPage.wait_for_credential()
         assert context.thisCredentialAddedPage.on_this_page()
-    except:
+    except Exception as e:
+        if "Unable to accept credential offer" in str(e) or "TimeoutException" in str(e):
+            raise e
         context.thisHomePage = context.thisCredentialOnTheWayPage.select_home()
 
 

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -436,8 +436,9 @@ def step_impl(context):
         else:
             # we are on the page but no error yet check one more time then close and scan again
             logging.info("There seems to be a problem scanning the QR Code, closing and scanning again")
-        context.thisQRCodeScanPage.select_close()
-        context.thisConnectingPage = context.thisNavBar.select_scan()
+        if context.thisQRCodeScanPage.on_this_page():
+            context.thisQRCodeScanPage.select_close()
+            context.thisConnectingPage = context.thisNavBar.select_scan()
 
 
 @given('the user has a connectionless {proof} request for access to PCTF')

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -3,6 +3,7 @@
 #
 # -----------------------------------------------------------
 
+import logging
 from behave import given, when, then
 import json
 from time import sleep
@@ -19,6 +20,7 @@ from pageobjects.bc_wallet.home import HomePage
 from pageobjects.bc_wallet.navbar import NavBar
 from pageobjects.bc_wallet.camera_privacy_policy import CameraPrivacyPolicyPage
 from pageobjects.bc_wallet.credentials import CredentialsPage
+from pageobjects.bc_wallet.scan import ScanPage
 
 
 @given('the holder has a Non-Revocable credential')
@@ -420,6 +422,22 @@ def step_impl(context):
             context.driver)
         if context.thisCameraPrivacyPolicyPage.on_this_page():
             context.thisCameraPrivacyPolicyPage.select_allow()
+    
+    # It is possible that the QR code scan page could have an error displayed like invalid QR code, or at times displays
+    # no message and just sits there waiting, like there is no qr code to scan. Check to see if there is an error message and if so,
+    # close the scan window and scan again.
+    if hasattr(context, 'thisQRCodeScanPage') == False:
+        context.thisQRCodeScanPage = ScanPage(context.driver)
+    if context.thisQRCodeScanPage.on_this_page():
+        sleep(5)
+        if "Invalid QR code" in context.thisQRCodeScanPage.get_page_source():
+            # log the issue and close the scan window and scan again
+            logging.info("Invalid QR code error on scan page, closing and scanning again")
+        else:
+            # we are on the page but no error yet check one more time then close and scan again
+            logging.info("There seems to be a problem scanning the QR Code, closing and scanning again")
+        context.thisQRCodeScanPage.select_close()
+        context.thisConnectingPage = context.thisNavBar.select_scan()
 
 
 @given('the user has a connectionless {proof} request for access to PCTF')

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -6,6 +6,7 @@
 from behave import given, when, then
 import json
 import os
+from decouple import config
 
 # Local Imports
 from agent_controller_client import agent_controller_GET, agent_controller_POST, expected_agent_state, setup_already_connected
@@ -82,10 +83,18 @@ def step_impl(context):
     assert context.thisHomePage.on_this_page()
 
     # set the environment to TEST instead of PROD which is default as of build 575
-    env = "Test"
-    context.execute_steps(f'''
-        Given the App environment is set to {env}
-    ''')
+    # check to see what the current environment is set to. Order of presendence is, Environment Variable, Tag, default. 
+    env = os.environ.get('BCWALLET_ENVIRONMENT')
+    
+    if not env:
+        for tag in context.tags:
+            if tag.startswith('@BCWALLET_ENVIRONMENT:'):
+                env = tag.split(':')[1]
+
+    if env:
+        context.execute_steps(f'''
+            Given the App environment is set to {env}
+        ''')
 
 
 @given('the App environment is set to {env}')

--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_on_the_way.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_on_the_way.py
@@ -15,6 +15,12 @@ class CredentialOnTheWayPage(BasePage):
     on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/CredentialOnTheWay")
     home_locator = (AppiumBy.ID, "com.ariesbifold:id/BackToHome")
 
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        # Instantiate possible Modals and Alerts for this page
+        self.unable_to_accept_credential_offer_modal = UnableToAcceptCredentialOfferModal(driver)
+
     def on_this_page(self):
         return super().on_this_page(self.on_this_page_locator)
 
@@ -27,24 +33,60 @@ class CredentialOnTheWayPage(BasePage):
             raise Exception(f"App not on the {type(self)} page")
 
     def wait_for_credential(self, timeout=300):
-        # Set up logging
-        logger = logging.getLogger(__name__)
 
         # Wait for the Credential On the way indicator to disappear
         try:
-            self.find_by(self.on_this_page_locator, timeout, WaitCondition.INVISIBILITY_OF_ELEMENT_LOCATED)
-            logger.debug("Credential On the way indicator disappeared")
+            # Make sure the unable to accept credential offer modal is not displayed
+            if not self.unable_to_accept_credential_offer_modal.is_displayed():
+                self.find_by(self.on_this_page_locator, timeout, WaitCondition.INVISIBILITY_OF_ELEMENT_LOCATED)
+                logging.debug("Credential On the way indicator disappeared")
+            else:
+                self.raise_exception_unable_to_accept_credential_offer()
         except TimeoutException:
-            logger.error(f"App Initialization taking longer than expected. Timing out at {timeout} seconds.")
+            logging.error(f"Getting Credential taking longer than expected. Timing out at {timeout} seconds.")
+            # Check if the unable to accept credential offer modal is displayed
+            if self.unable_to_accept_credential_offer_modal.is_displayed():
+                self.raise_exception_unable_to_accept_credential_offer()
             raise
 
         # Return the HomePage object
         return CredentialAddedPage(self.driver)
 
-    # def select_cancel(self):
-    #     if self.on_this_page():
-    #         self.find_by_accessibility_id(self.cancel_locator).click()
-    #         from pageobjects.bc_wallet.home import HomePage
-    #         return HomePage(self.driver)
-    #     else:
-    #         raise Exception(f"App not on the {type(self)} page")
+    def raise_exception_unable_to_accept_credential_offer(self):
+        # Get the main error
+        main_error = self.unable_to_accept_credential_offer_modal.get_main_error()
+        # Get the detailed error
+        self.unable_to_accept_credential_offer_modal.select_show_details()
+        detailed_error = self.unable_to_accept_credential_offer_modal.get_detailed_error()
+        # Select Okay
+        self.unable_to_accept_credential_offer_modal.select_okay()
+        # Raise an exception
+        raise Exception(f"Unable to accept credential offer. Main Error: {main_error}. Detailed Error: {detailed_error}")
+
+class UnableToAcceptCredentialOfferModal(BasePage):
+    """Unable to Accept Credential Offer Modal page object"""
+
+    # Locators
+    on_this_page_text_locator = "Unable to accept credential offer."
+    error_locator = (AppiumBy.ID, "com.ariesbifold:id/BodyText")
+    show_details_locator = (AppiumBy.ID, "com.ariesbifold:id/ShowDetails")
+    okay_locator = (AppiumBy.ID, "com.ariesbifold:id/Okay") 
+
+    def on_this_page(self):
+        return super().on_this_page(self.on_this_page_text_locator)
+    
+    def is_displayed(self):
+        return self.on_this_page()
+
+    def get_main_error(self) -> str:
+        return self.find_by(self.error_locator).text
+        
+    def select_show_details(self):
+        self.find_by(self.show_details_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+    def get_detailed_error(self) -> str:
+        return self.find_by(self.error_locator).text
+
+    def select_okay(self):
+        self.find_by(self.okay_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+

--- a/aries-mobile-tests/pageobjects/bc_wallet/initialization.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/initialization.py
@@ -21,12 +21,27 @@ class InitializationPage(BasePage):
     error_details_locator = (AppiumBy.ID, "com.ariesbifold:id/DetailsText")
     error_okay_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Okay")
 
+    def __init__(self, driver):
+        super().__init__(driver)
+        # Instantiate possible Modals and Alerts for this page
+        self.oops_something_went_wrong_modal = OopsSomethingWentWrongModal(driver)
+
     def on_this_page(self):
-        #return super().on_this_page(self.on_this_page_text_locator)
-        #print(self.driver.page_source)
         return self.still_initializing()
 
     def still_initializing(self):
+        # Check for something went wrong modal
+        if self.oops_something_went_wrong_modal.is_displayed():
+            # Get the main error
+            main_error = self.oops_something_went_wrong_modal.get_main_error()
+            # if Timeout error, then raise exception
+            if self.oops_something_went_wrong_modal.is_timeout_error():
+                raise Exception(main_error)
+            else:
+                # Otherwise, Show details, and get the details message and raise exception
+                self.oops_something_went_wrong_modal.select_show_details()
+                detailed_error = self.oops_something_went_wrong_modal.get_detailed_error()
+                raise Exception(f"{main_error}\n{detailed_error}")
         try:
             self.find_by(self.loading_locator)
             return True
@@ -34,28 +49,61 @@ class InitializationPage(BasePage):
             return False
 
 
-    def wait_until_initialized(self, timeout=100):
-        # Set up logging
+    def wait_until_initialized(self, timeout=100, retry_attempts=3):
         logger = logging.getLogger(__name__)
 
-        # Wait for the loading indicator to disappear
-        try:
-            self.find_by(self.loading_locator, timeout, WaitCondition.INVISIBILITY_OF_ELEMENT_LOCATED)
-            logger.debug("Loading indicator disappeared")
-        except TimeoutException:
-            # TODO add in a check for the timeout error message from the app. 
-            logger.error(f"App Initialization taking longer than expected. Timing out at {timeout} seconds.")
-            logger.error(f"Checking Initialization for error...")
-            if self.find_by(self.error_intializing_locator):
-                error_title = self.find_by(self.error_intializing_locator).text
-                error_message = self.find_by(self.error_message_locator).text
-                self.find_by(self.error_details_link_locator).click()
-                error_details = self.find_by(self.error_message_locator).text
-                logger.error(f"BC Wallet Error: {error_title}\n{error_message}\n{error_details}")
-                self.find_by(self.error_okay_button_locator).click()
-                # not sure what to do after this? Should I try and restart the app?
-                #raise Exception(f"Error occurred during app initialization: {error_message}")
-            raise
-
-        # Return the HomePage object
+        for i in range(retry_attempts):
+            try:
+                if self.still_initializing():
+                    self.find_by(self.loading_locator, timeout, WaitCondition.INVISIBILITY_OF_ELEMENT_LOCATED)
+                    logger.debug("Loading indicator disappeared")
+                else:
+                    return HomePage(self.driver)
+            except TimeoutException:
+                try:
+                    self.still_initializing()
+                except Exception as e:
+                    if "Oops! Something went wrong" in str(e):
+                        logger.error(f"Oops! Something went wrong. {e}")
+                        self.oops_something_went_wrong_modal.select_retry()
+                    else:
+                        raise
+            except Exception as e:
+                if "Oops! Something went wrong" in str(e):
+                    logger.error(f"Oops! Something went wrong. {e}")
+                    self.oops_something_went_wrong_modal.select_retry()
+                else:
+                    raise
         return HomePage(self.driver)
+
+class OopsSomethingWentWrongModal(BasePage):
+    """Oops! Something went wrong Modal page object"""
+
+    # Locators
+    on_this_page_text_locator = "Oops! Something went wrong"
+    main_error_locator = (AppiumBy.ID, "com.ariesbifold:id/BodyText")
+    show_details_locator = (AppiumBy.ID, "com.ariesbifold:id/ShowDetails")
+    detailed_error_locator = (AppiumBy.ID, "com.ariesbifold:id/DetailsText")
+    retry_locator = (AppiumBy.ID, "com.ariesbifold:id/Retry")
+
+    def on_this_page(self):
+        return super().on_this_page(self.on_this_page_text_locator)
+    
+    def is_displayed(self):
+        return self.on_this_page()
+    
+    def is_timeout_error(self):
+        return "Timeout" in self.get_main_error()
+
+    def get_main_error(self) -> str:
+        return self.find_by(self.main_error_locator).text
+        
+    def select_show_details(self):
+        self.find_by(self.show_details_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+    def get_detailed_error(self) -> str:
+        return self.find_by(self.detailed_error_locator).text
+
+    def select_retry(self):
+        self.find_by(self.okay_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+

--- a/aries-mobile-tests/pageobjects/bc_wallet/scan.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/scan.py
@@ -1,0 +1,35 @@
+import logging
+from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import BasePage
+from pageobjects.basepage import WaitCondition
+
+
+# These classes can inherit from a BasePage to do common setup and functions
+class ScanPage(BasePage):
+    """Camera Scan page object"""
+
+    # Locators
+    close_locator = (AppiumBy.ID, "com.ariesbifold:id/ScanClose")
+    flash_locator = (AppiumBy.ID, "com.ariesbifold:id/ScanTorch")
+    error_locator = (AppiumBy.ID, "com.ariesbifold:id/ErrorText")
+
+    def on_this_page(self):
+        return super().on_this_page(self.close_locator)
+
+    def get_error(self) -> str:
+        return self.find_by(self.error_locator).text
+        
+    def select_close(self):
+        if self.on_this_page():
+            try:
+                self.find_by(self.close_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+            except:
+                logging.warning("Soft Assert: Could not select close button on scan page. Assuming scan was successful and is connecting.")
+            # This goes to the page that called it could be one of may app pages. Let the test handle it.
+        else:
+            # we may have already moved on from this page.
+            logging.warning(f"Soft Assert: App not on the {type(self)} page. Assuming scan was successful and is connecting.")
+
+    def select_flash(self):
+        self.find_by(self.flash_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+


### PR DESCRIPTION
This BC Wallet PR adds handling for scanning QR codes and following issue credential issues. 
When scanning a QR code, the wallet with sometimes says the QR code is invalid. At times, on android, it also just sits on the scan screen with no error. This update will now check for that, so a soft assert so that we are aware of an issue, close the scan screen, re-upload the QR Code to the device and scan again. 

If there is a problem accepting a credential offer. The tests will now check for that error, show the details if there are any, and then log it for debugging use later. 

If there is a problem initializing, the tests will now check for an error, show the details if there are any, then do a soft assert so that we are aware of the issue, and then retry initialization. 

This PR also externalizes the BCW test environments setting external of the test. So now you can specify an environment variable or a tag in the feature file to tell the tests to use a specific environment that is set in BCW developer settings. 