### PR TITLE
home to notifications change

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -528,7 +528,7 @@ def step_impl(context):
         Then the holder selects the revocation notification
         Then acknowledges the revocation notification
     ''')
-    context.thisHomePage = context.thisNavBar.select_home()
+    context.thisHomePage = context.thisCredentialDetailsPage.select_back()
 
 
 @when(u'the holder selects the credential')

--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_details.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_details.py
@@ -11,12 +11,12 @@ class CredentialDetailsPage(BasePage):
     
     # Locators
     on_this_page_text_locator = "Credential Details"
-    #back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
-    back_locator = (AppiumBy.ACCESSIBILITY_ID, "Back")
+    back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
+    #back_locator = (AppiumBy.ACCESSIBILITY_ID, "Back")
     revocation_dismiss_locator = (AppiumBy.ID, "com.ariesbifold:id/Dismiss")
     revocation_message_locator = (AppiumBy.ID, "com.ariesbifold:id/BodyText")
     revocation_status_locator = (AppiumBy.ID, "com.ariesbifold:id/RevokedDate")
-    revocation_info_locator = (AppiumBy.ID, "com.ariesbifold:id/RevocationInfo")
+    revocation_info_locator = (AppiumBy.ID, "com.ariesbifold:id/RevocationMessage")
 
 
     def on_this_page(self):

--- a/aries-mobile-tests/pageobjects/bc_wallet/home.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/home.py
@@ -12,10 +12,10 @@ from time import sleep
 
 
 class HomePage(BasePage):
-    """Home page object"""
+    """Notifications (Home) page object"""
 
     # Locators
-    on_this_page_text_locator = "Home"
+    on_this_page_text_locator = "Notifications"
     on_this_page_notification_locator = "New Credential Offer"
     on_this_page_proof_notification_locator = "New Proof Request"
     on_this_page_revocation_notification_locator = "Credential revoked"

--- a/aries-mobile-tests/pageobjects/bc_wallet/navbar.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/navbar.py
@@ -10,14 +10,14 @@ class NavBar(BasePage):
 
     # Locators
     scan_locator = (AppiumBy.ID, "com.ariesbifold:id/Scan")
-    home_locator = (AppiumBy.ID, "com.ariesbifold:id/Home")
+    notifications_locator = (AppiumBy.ID, "com.ariesbifold:id/Notifications")
     credentials_locator = (AppiumBy.ID, "com.ariesbifold:id/Credentials")
     settings_locator = (AppiumBy.ID, "com.ariesbifold:id/Settings")
     notification_locator = (AppiumBy.ID, "com.ariesbifold:id/Notification")
     
 
     def select_home(self):
-        self.find_by(self.home_locator).click()
+        self.find_by(self.notifications_locator).click()
         return HomePage(self.driver)
 
     def select_scan(self):
@@ -39,8 +39,8 @@ class NavBar(BasePage):
     def has_notification(self):
         try:
             # get the home element and check for the word notifications on the element text.
-            home_element = self.find_by(self.home_locator)
-            if "0 Notifications" in home_element.text:
+            notifications_element = self.find_by(self.notifications_locator)
+            if "0 Notifications" in notifications_element.text:
                 return False
             else:
                 return True


### PR DESCRIPTION
This PR calibrates the tests to the BC Wallet 1105 build where the "Home" page and associated labels have been change to "Notifications". 

It also fixes a revocation test where a testID has changes somewhere along the way and a locator by accessibility label is no longer working (a request has been logged in the bc wallet repo for a new testID).