### PR TITLE
BCW BC Digital ID test calibration to build 1119

### DIFF
--- a/aries-mobile-tests/agent_factory/bc_vp/pageobjects/invites_page.py
+++ b/aries-mobile-tests/agent_factory/bc_vp/pageobjects/invites_page.py
@@ -17,7 +17,7 @@ class InvitesPage(WebBasePage):
     search_locator = (By.XPATH, "(//input[@type='text'])[1]")
     row_locator = (By.CLASS_NAME, "v-input--selection-controls__ripple")
     edit_invite_locator = (By.XPATH, "(//button[@type='button'])[2]")
-    credential_has_been_issued_locator = (By.XPATH, "//div[@class='v-input--selection-controls__ripple primary--text']")
+    credential_has_been_issued_locator = (By.XPATH, "(//div[@class='v-input--selection-controls__ripple'])[1]")
     save_locator = (By.XPATH, "//button[@class='v-btn v-btn--outlined theme--light v-size--default success--text']")
     #invitation_url_locator = (By.XPATH, '(//a[contains(text(),'https://bcvcpilot-issuer-test.apps.silver.devops.gov.bc.ca')])[1]')
     invitation_url_locator = (By.PARTIAL_LINK_TEXT, 'https://bcvcpilot-issuer-test.apps.silver.devops.gov.bc.ca')
@@ -40,8 +40,13 @@ class InvitesPage(WebBasePage):
             raise Exception(f"App not on the {type(self)} page")
 
     def uncheck_issued(self):
-        # TODO check if already unchecked
-        self.find_by(self.credential_has_been_issued_locator).click()
+        checkbox = self.find_by(self.credential_has_been_issued_locator)
+    
+        if checkbox.is_selected():
+            checkbox.click()
+            if checkbox.is_selected():
+                raise Exception("Could not uncheck the 'Credential has been issued' checkbox")
+        
         return True
 
     def save_invite(self):

--- a/aries-mobile-tests/features/steps/bc_wallet/bcsc.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/bcsc.py
@@ -47,6 +47,8 @@ def step_impl(context, credential):
         Given the BCVC Issuer sends a BC VC Pilot Certificate
         And the BCSC holder gets the invite QR Code from their email
         And they Scan the credential offer QR Code
+        And the Connecting completes successfully
+        And the holder opens the credential offer
         Then holder is brought to the credential offer screen
         When they select Accept
         And the holder is informed that their credential is on the way with an indication of loading

--- a/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/credential_offer.py
@@ -3,7 +3,7 @@
 #
 # -----------------------------------------------------------
 
-from behave import given, when, then
+from behave import given, when, then, step
 import json
 from time import sleep
 
@@ -40,7 +40,7 @@ def step_impl(context):
     assert context.thisContactPage.wait_for_credential_offer()
 
 
-@when('the holder opens the credential offer')
+@step('the holder opens the credential offer')
 def step_impl(context):
     # Select the credential offer
     context.thisCredentialOfferPage = context.thisContactPage.select_open_credential_offer()
@@ -87,8 +87,8 @@ def step_impl(context, credential, revocation=None):
                 print(
                     f"FileNotFoundError: features/data/schema_{cred_type.lower()}.json")
         else:
-            if "Connectionless" in context.tags:
-                # We are expecting a QR code on the send credential if connectionless
+            if "Connectionless" in context.tags or context.issuer.get_issuer_type() == "CANdyUVPIssuer":
+                # We are expecting a QR code on the send credential if connectionless or the issuer is a CANdyUVPIssuer
                 qrimage = context.issuer.send_credential(
                     credential_offer=credential_json)
                 context.device_service_handler.inject_qrcode(qrimage)
@@ -110,6 +110,7 @@ def step_impl(context):
 @then('holder is brought to the credential offer screen')
 def step_impl(context):
     # Workaround for bug 645
+    # TODO remove this when bug 645 is fixed. It looks like there is no reason to run this anymore July 7, 2023
     context.execute_steps(f'''
         When the connection takes too long reopen app and select notification
     ''')

--- a/aries-mobile-tests/pageobjects/bc_wallet/contact.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/contact.py
@@ -21,7 +21,7 @@ class ContactPage(BasePage):
     send_message_locator = (AppiumBy.ID, "com.ariesbifold:id/SendMessage")
     credential_offer_message_locator = (AppiumBy.XPATH, '//*[contains(@accessibilityId, "sent a credential offer")]')
     proof_request_message_locator = (AppiumBy.XPATH, '//*[contains(@accessibilityId, "sent a proof request")]')
-    open_credential_offer_locator = (AppiumBy.ID, "com.ariesbifold:id/ViewOffer")
+    open_credential_offer_locator = (AppiumBy.ID, "com.ariesbifold:id/Viewoffer")
     open_proof_request_locator = (AppiumBy.ID, "com.ariesbifold:id/ViewRequest")
 
     def on_this_page(self):     


### PR DESCRIPTION
This PR updates the BC Wallet Credential Offer page object with the updates `Viewoffer` test ID. It also brings the related BC Digital tests scenarios up to build 1119 including the new process of scanning the QR code and going to the contact screen instead of the red offer right away.