### PR TITLE
Added apple.com to sauce tunnel direct domains

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-          directDomains: aries-mediator-agent.vonx.io
+          directDomains: aries-mediator-agent.vonx.io,apple.com
 
       #    tunnelIdentifier: github-action-tunnel
       #    region: us-west-1


### PR DESCRIPTION
Adding apple.com to the direct domains of the sauce tunnel.  In newer profiles for newer devices, Apple auto-enabled the PPQCheck flag to true which results in an extra API call to Apple. This extra PPQCheck API call is typically not allowed by default in most users' network configurations.

This is to test if the skipped iOS tests in the highly test pipeline are eliminated or diminished. 