### PR TITLE
Appium upgrade remove mobileby

### DIFF
--- a/aries-mobile-tests/device_service_handler/device_service_handler_interface.py
+++ b/aries-mobile-tests/device_service_handler/device_service_handler_interface.py
@@ -4,6 +4,7 @@ Absctact Base Class for actual device service handler interfaces to implement
 
 from abc import ABC, abstractmethod
 from appium import webdriver
+from appium.options.common import AppiumOptions
 import os
 import json
 
@@ -12,6 +13,7 @@ class DeviceServiceHandlerInterface(ABC):
 
     _CONFIG: dict
     _driver: webdriver
+    _options: AppiumOptions
 
     def __init__(self, config_file_path: str):
         print("Path to the config file = %s" % (config_file_path))
@@ -21,6 +23,7 @@ class DeviceServiceHandlerInterface(ABC):
         # Set the device service specific options to default. 
         # This can be overridden if the user calls this method again with parameters.
         self.set_device_service_specific_options()
+        self._options = AppiumOptions()
 
     @abstractmethod
     def set_device_service_specific_options(self, options:dict=None, command_executor_url:str=None):
@@ -36,8 +39,9 @@ class DeviceServiceHandlerInterface(ABC):
             url = self._url
         else:
             url = command_executor_url
+            
         self._driver = webdriver.Remote(
-            desired_capabilities=self._desired_capabilities,
+            options=self._options,
             command_executor=url,
             keep_alive=False
         )

--- a/aries-mobile-tests/device_service_handler/sauce_labs_handler.py
+++ b/aries-mobile-tests/device_service_handler/sauce_labs_handler.py
@@ -34,6 +34,8 @@ class SauceLabsHandler(DeviceServiceHandlerInterface):
         print("\n\nDesired Capabilities passed to Appium:")
         print(json.dumps(self._desired_capabilities, indent=4))
 
+        self._set_appium_options_from_desired_capabilities()
+
     def set_device_service_specific_options(self, options: dict = None, command_executor_url: str = None):
         """set any specific device options before initialize_driver is called """
         """Order of presededence is options parameter, then the config.json file, then environment variables"""
@@ -70,6 +72,12 @@ class SauceLabsHandler(DeviceServiceHandlerInterface):
 
         # print(url)
 
+
+    def _set_appium_options_from_desired_capabilities(self):
+        """set the appium options from the desired capabilities"""
+        #self._options = webdriver.AppiumOptions()
+        for key in self._desired_capabilities:
+            self._options.set_capability(key, self._desired_capabilities[key])
 
     def inject_qrcode(self, image):
         """pass the qrcode image to the device in a way that allows for the device to scan it when the camera opens"""

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -11,7 +11,7 @@ from time import sleep
 # Local Imports
 from agent_controller_client import agent_controller_GET, agent_controller_POST, expected_agent_state, setup_already_connected
 from agent_test_utils import get_qr_code_from_invitation
-from appium.webdriver.common.mobileby import MobileBy
+from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from appium.webdriver.common.touch_action import TouchAction
@@ -23,10 +23,10 @@ from pageobjects.bc_wallet.no_internet_toast_notification import NoInternetConne
 def step_impl(context):
     if context.driver.capabilities['platformName'] == 'iOS':
         height = WebDriverWait(context.driver, 30).until(
-                EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+                EC.presence_of_element_located((AppiumBy.CLASS_NAME, "UIAWindow"))
             ).size["height"]
         width = WebDriverWait(context.driver, 30).until(
-                EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+                EC.presence_of_element_located((AppiumBy.CLASS_NAME, "UIAWindow"))
             ).size["width"]
         if '6' in context.driver.capabilities['testobject_device_name']:
             # Access Control panel with a swipe up from the bottom
@@ -82,11 +82,11 @@ def step_impl(context):
     if context.driver.capabilities['platformName'] == 'iOS':
         # Get screen height
         height = WebDriverWait(context.driver, 30).until(
-            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+            EC.presence_of_element_located((AppiumBy.CLASS_NAME, "UIAWindow"))
         ).size["height"]
         # Get screen width
         width = WebDriverWait(context.driver, 30).until(
-            EC.presence_of_element_located((MobileBy.CLASS_NAME, "UIAWindow"))
+            EC.presence_of_element_located((AppiumBy.CLASS_NAME, "UIAWindow"))
         ).size["width"]
 
         # swipe down on the right to open control center

--- a/aries-mobile-tests/pageobjects/basepage.py
+++ b/aries-mobile-tests/pageobjects/basepage.py
@@ -1,6 +1,5 @@
 import time
 from enum import Enum
-from appium.webdriver.common.mobileby import MobileBy
 from appium.webdriver.common.appiumby import AppiumBy
 from appium.webdriver.common.touch_action import TouchAction
 from selenium.webdriver.support.ui import WebDriverWait
@@ -53,9 +52,9 @@ class BasePage(object):
         self.current_platform = driver.capabilities['platformName']
 
     def find_by(self, locator_tpl: tuple, timeout=20, wait_condition:WaitCondition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED):
-        if locator_tpl[0] == MobileBy.ACCESSIBILITY_ID or locator_tpl[0] == AppiumBy.ACCESSIBILITY_ID:
+        if locator_tpl[0] == AppiumBy.ACCESSIBILITY_ID:
             return self.find_by_accessibility_id(locator_tpl[1], timeout, wait_condition)
-        elif locator_tpl[0] == MobileBy.ID or locator_tpl[0] == AppiumBy.ID:
+        elif locator_tpl[0] == AppiumBy.ID:
             return self.find_by_element_id(locator_tpl[1], timeout, wait_condition)
         else:
             try:
@@ -69,9 +68,9 @@ class BasePage(object):
 
 
     def find_multiple_by(self, locator_tpl: tuple, timeout=20):
-        if locator_tpl[0] == MobileBy.ACCESSIBILITY_ID or locator_tpl[0] == AppiumBy.ACCESSIBILITY_ID:
+        if locator_tpl[0] == AppiumBy.ACCESSIBILITY_ID:
             return self.find_multiple_by_accessibility_id(locator_tpl[1], timeout)
-        elif locator_tpl[0] == MobileBy.ID or locator_tpl[0] == AppiumBy.ID:
+        elif locator_tpl[0] == AppiumBy.ID:
             # It may be that Android will return none when looking for multiple
             # so if we get an empty element array here try find_by instead.
             elems = self.find_multiple_by_id(locator_tpl[1], timeout)
@@ -186,7 +185,7 @@ class BasePage(object):
         else:
             # Message: Mobile scroll supports the following strategies: name, direction, predicateString, and toVisible. Specify one of these
             # iOS
-            el = self.driver.find_element(MobileBy.ACCESSIBILITY_ID, locator)
+            el = self.driver.find_element(AppiumBy.ACCESSIBILITY_ID, locator)
             self.driver.execute_script("mobile: scroll", {"direction": direction, 'element': el})
 
     def scroll_to_bottom(self):

--- a/aries-mobile-tests/pageobjects/bc_wallet/allownotifications.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/allownotifications.py
@@ -1,10 +1,5 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.home import HomePage
-#from pageobjects.bc_wallet.secure import SecurePage
 
 # These classes can inherit from a BasePage to do commone setup and functions
 class AllowNotificationsPage(BasePage):

--- a/aries-mobile-tests/pageobjects/bc_wallet/biometrics.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/biometrics.py
@@ -1,11 +1,5 @@
 import os
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.pinsetup import PINSetupPage
-from pageobjects.bc_wallet.initialization import InitializationPage
 
 class BiometricsPage(BasePage):
     """Biometrics enter page object"""

--- a/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
@@ -1,6 +1,4 @@
-from appium.webdriver.common.mobileby import AppiumBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
 from pageobjects.basepage import WaitCondition
 

--- a/aries-mobile-tests/pageobjects/bc_wallet/information_approved.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/information_approved.py
@@ -1,9 +1,5 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
-#from pageobjects.bc_wallet.home import HomePage
 
 
 # These classes can inherit from a BasePage to do common setup and functions
@@ -12,8 +8,8 @@ class InformationApprovedPage(BasePage):
 
     # Locators
     on_this_page_text_locator = "Information received"
-    approval_locator = (MobileBy.ID, "com.ariesbifold:id/SentProofRequest")
-    done_locator = (MobileBy.ID, "com.ariesbifold:id/Done")
+    approval_locator = (AppiumBy.ID, "com.ariesbifold:id/SentProofRequest")
+    done_locator = (AppiumBy.ID, "com.ariesbifold:id/Done")
 
     def on_this_page(self):
         #print(self.driver.page_source)

--- a/aries-mobile-tests/pageobjects/bc_wallet/languagesplash.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/languagesplash.py
@@ -1,7 +1,3 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.onboardingwelcome import OnboardingWelcomePage
 

--- a/aries-mobile-tests/pageobjects/bc_wallet/no_internet_toast_notification.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/no_internet_toast_notification.py
@@ -1,4 +1,4 @@
-from appium.webdriver.common.mobileby import MobileBy
+from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.bc_wallet.toast_notification import ToastNotification
 
 class NoInternetConnectionToastNotification(ToastNotification):
@@ -6,6 +6,6 @@ class NoInternetConnectionToastNotification(ToastNotification):
 
     # Locators
     on_this_page_text_locator = "No internet connection"
-    notification_locator = (MobileBy.ID, "com.ariesbifold:id/ToastTitle")
+    notification_locator = (AppiumBy.ID, "com.ariesbifold:id/ToastTitle")
 
 

--- a/aries-mobile-tests/pageobjects/bc_wallet/pin.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/pin.py
@@ -1,9 +1,5 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.home import HomePage
 from pageobjects.bc_wallet.initialization import InitializationPage
 
 class PINPage(BasePage):
@@ -11,9 +7,9 @@ class PINPage(BasePage):
 
     # Locators
     on_this_page_text_locator = "Enter PIN"
-    pin_locator = (MobileBy.ID, "com.ariesbifold:id/EnterPIN")
-    pin_visibility_locator = (MobileBy.ID, "com.ariesbifold:id/Show")
-    enter_button_locator = (MobileBy.ID, "com.ariesbifold:id/Enter")
+    pin_locator = (AppiumBy.ID, "com.ariesbifold:id/EnterPIN")
+    pin_visibility_locator = (AppiumBy.ID, "com.ariesbifold:id/Show")
+    enter_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Enter")
 
     def on_this_page(self):   
         return super().on_this_page(self.on_this_page_text_locator, 50) 

--- a/aries-mobile-tests/pageobjects/bc_wallet/proof_request_details.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/proof_request_details.py
@@ -1,5 +1,5 @@
 import time
-from appium.webdriver.common.mobileby import MobileBy
+from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
@@ -11,8 +11,8 @@ class ProofRequestDetailsPage(BasePage):
     
     # Locators
     on_this_page_text_locator = "which you can provide from:"
-    back_locator = (MobileBy.ID, "com.ariesbifold:id/back")
-    credential_locator = (MobileBy.ID, "com.ariesbifold:id/AttributeName")
+    back_locator = (AppiumBy.ID, "com.ariesbifold:id/back")
+    credential_locator = (AppiumBy.ID, "com.ariesbifold:id/AttributeName")
 
 
     def on_this_page(self):

--- a/aries-mobile-tests/pageobjects/bc_wallet/secure.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/secure.py
@@ -1,7 +1,3 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.allownotifications import AllowNotificationsPage
 

--- a/aries-mobile-tests/pageobjects/bc_wallet/sending_information_securely.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/sending_information_securely.py
@@ -1,9 +1,4 @@
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
-#from pageobjects.bc_wallet.home import HomePage
 
 
 # These classes can inherit from a BasePage to do common setup and functions

--- a/aries-mobile-tests/pageobjects/bc_wallet/toast_notification.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/toast_notification.py
@@ -1,11 +1,5 @@
 import os
-import time
-from appium.webdriver.common.mobileby import MobileBy
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.pinsetup import PINSetupPage
-from pageobjects.bc_wallet.initialization import InitializationPage
 
 class ToastNotification(BasePage):
     """base class for the toast notification page object"""


### PR DESCRIPTION
A recent upgrade to appium-python-client (3.0.0) has removed some deprecated ways of doing a couple things that were still lingering around in the Aries Mobile Test Harness. This PR adjusts the Test Harness and the BC Wallet for this update. 

1/ In the Test Harness, we were still using desired_capabilities when creating the appium driver. This has been replaced with AppiumOptions. 

This may affect the LamdaTest and the localAndroid device handlers. So those may have to change as well. 

2/ MobileBy locator types has been removed and now only supports AppiumBy. All BC Wallet page objects and the test harness page object base class has been updated to use strictly AppiumBy. 

All users of AMTH will have to adjust their page objects if they have any lingering MobileBy references. 