### PR TITLE
Fix for feature "Scan QR code to recieve a credential offer" in connect.feature

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -10,6 +10,7 @@ Feature: Connections
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the Holder has selected to use biometrics to unlock BC Wallet
       When the Holder scans the QR code sent by the "issuer"
       And the Holder is taken to the Connecting Screen/modal
       And the Connecting completes successfully

--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -5,7 +5,7 @@
 Feature: Connections
 
 
-   @T001-Connect @wip @critical @AcceptanceTest
+   @T001-Connect @critical @AcceptanceTest
    Scenario: Scan QR code to recieve a credential offer
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions

--- a/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
@@ -35,9 +35,9 @@ class CameraPrivacyPolicyPage(BasePage):
 
     def select_allow(self):
         # 26 sec
-        #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+        self.find_by(self.allow_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
         # 19 sec
-        self.find_by(self.allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
         # 28 sec
         #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED).click()
         # 22 sec


### PR DESCRIPTION
**Error existed**
Not able to find Scan button as the Biometric page was not handled 
![image](https://github.com/hyperledger/aries-mobile-test-harness/assets/79985154/711e4746-463f-43ec-8781-bf55eda5683c)

**Changes made**

> Added line to use biometrics
> Changed the way to find Allow button on IOS devices

Test Result
![image](https://github.com/hyperledger/aries-mobile-test-harness/assets/79985154/3ae0989e-55d1-4fd4-81b2-832586ccc9f2)
