### PR TITLE
BCW fixed Give Feedback test for android

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/feedback.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/feedback.py
@@ -9,6 +9,7 @@ class FeedbackPage(BasePage):
     on_this_page_text_locator = "Give Feedback"
     next_locator = (AppiumBy.ACCESSIBILITY_ID, "Next")
     exit_locator = (AppiumBy.ACCESSIBILITY_ID, "EXIT") # Works on iOS
+    exit_locator_android = (AppiumBy.XPATH, "//android.widget.Button[@text='EXIT']")
 
 
     def on_this_page(self):   
@@ -25,7 +26,10 @@ class FeedbackPage(BasePage):
 
     def select_exit(self):
         if self.on_this_page():
-            self.find_by(self.exit_locator).click()
+            if self.driver.desired_capabilities['platformName'] == 'Android':
+                self.find_by(self.exit_locator_android).click()
+            else:
+                self.find_by(self.exit_locator).click()
             from pageobjects.bc_wallet.home import HomePage
             return HomePage(self.driver)
         else:


### PR DESCRIPTION
There was an issue with the BC Wallet tests where getting the EXIT locator on the feedback entry page was not locatable by the Accessibility id of EXIT on Android as it is on iOS. Changed the Android locator to XPATH with text of EXIT.