### PR TITLE
Fix for "Holder accepts a proof request with multiple credentials"

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -220,7 +220,10 @@ def step_impl(context):
         for credential_card_text in credential_card_text_list:
             if credential_name in credential_card_text:
                 # if the credential name is in the card check to see if the attributes are in the card
-                assert attribute.replace("_", " ").title() in credential_card_text
+                # As attributes comes in small cases and with underscore in credential_card_text 
+                # eg value of credential_card_text : Issued by aca-py.Acme,  Photo Id credential. issue_date, 2022-04-04T13:32:55.455Z, birth_dateint, > 19420116,,
+                # assert attribute.replace("_", " ").title() in credential_card_text
+                assert attribute.lower() in credential_card_text.lower()
                 break
 
 @when('the user has a proof request')

--- a/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/camera_privacy_policy.py
@@ -33,9 +33,9 @@ class CameraPrivacyPolicyPage(BasePage):
 
     def select_allow(self):
         # 26 sec
-        self.find_by(self.continue_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+        # self.find_by(self.continue_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
         # 19 sec
-        #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        self.find_by(self.continue_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
         # 28 sec
         #self.find_by(self.allow_button_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED).click()
         # 22 sec


### PR DESCRIPTION
Fix for scenario **"Holder accepts a proof request with multiple credentials**" 

1) As attributes comes in small cases and with underscore in **credential_card_text** 
eg value of credential_card_text : **Issued by aca-py.Acme,  Photo Id credential. issue_date, 2022-04-04T13:32:55.455Z, birth_dateint,** 

- Commented logic to replace underscore
- Check arribute present or not in small cases

Using PRESENCE_OF_ELEMENT_LOCATED as it is faster

Test passed in both IOS and Android
https://app.saucelabs.com/tests/d94f13e6fa204f1a88152d98e4f95d99#294
https://app.saucelabs.com/tests/21db0e6a53e84685afbba3a8d50a51ef