### PR TITLE
BCW added new testids to locators for get person cred page

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/get_person_credential.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/get_person_credential.py
@@ -10,8 +10,10 @@ class GetPersonCredentialPage(BasePage):
 
     # Locators
     on_this_page_text_locator = "Person Credential"
-    get_your_person_credential_locator = (AppiumBy.ACCESSIBILITY_ID, "Get your Person credential")
-    get_this_later_locator = (AppiumBy.ACCESSIBILITY_ID, "Get this later")
+    #get_your_person_credential_locator = (AppiumBy.ACCESSIBILITY_ID, "Get your Person credential")
+    get_your_person_credential_locator = (AppiumBy.ID, "com.ariesbifold:id/GetYourPersonCredential")
+    #get_this_later_locator = (AppiumBy.ACCESSIBILITY_ID, "Get this later")
+    get_this_later_locator = (AppiumBy.ID, "com.ariesbifold:id/GetThisLater")
 
     def on_this_page(self):
         return super().on_this_page(self.on_this_page_text_locator)


### PR DESCRIPTION
The Get Person Credential page in BC Wallet was missing testIDs. They were added recently so this PR switches to use them as locators.