### PR TITLE
BCW Special and Extended characters tests

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -74,6 +74,27 @@ Feature: Proof
          | cred_data_photo_id | proof_photo_id |
 
 
+   @T002.2-Proof @normal @FunctionalTest @Story_29
+   Scenario Outline: Holder accepts the proof request credential has special characters
+      Given the User has skipped on-boarding
+      And the User has accepted the Terms and Conditions
+      And a PIN has been set up with "369369"
+      And the Holder has selected to use biometrics to unlock BC Wallet
+      And the holder has credentials
+         | credential                        | revocable | issuer_agent_type | credential_name    |
+         | cred_data_drivers_license_sp_char | True      | AATHIssuer        | Drivers License 😀 |
+      And the user has a proof request for <proof>
+      When they select Share
+      And the holder is informed that they are sending information securely
+      And they are informed that the information sent successfully
+      And they select Go back to home on information sent successfully
+      Then they are brought Home
+
+      Examples:
+         | proof                         |
+         | proof_drivers_license_sp_char |
+
+
    @T003-Proof @critical @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a revoked credential where the verifier cares if the credential was revoked
       Given the User has skipped on-boarding

--- a/aries-mobile-tests/features/data/cred_data_drivers_license_sp_char.json
+++ b/aries-mobile-tests/features/data/cred_data_drivers_license_sp_char.json
@@ -1,0 +1,46 @@
+{
+   "schema_name": "drivers_license_😀",
+   "schema_version": "1.0.0",
+   "attributes": [
+      {
+         "name": "name_😀",
+         "value": "Betty Naroff 😀"
+      },
+      {
+         "name": "civic_address_!@#",
+         "value": "159 Cedar Street, Sudbury, ON"
+      },
+      {
+         "name": "city_$%^",
+         "value": "Sudbury"
+      },
+      {
+         "name": "province_&*(",
+         "value": "ON"
+      },
+      {
+         "name": ")_+_country",
+         "value": "Canada"
+      },
+      {
+         "name": "~!@_postal_code",
+         "value": "P3E 1B1"
+      },
+      {
+         "name": "#$%_birth_dateint",
+         "value": "19420117"
+      },
+      {
+         "name": "^&*_id",
+         "value": "123456789"
+      },
+      {
+         "name": "issue_()_date",
+         "value": "2022-04-04T13:32:55.455Z"
+      },
+      {
+         "name": "expiry_/0_date",
+         "value": "2027-04-04T13:32:55.455Z"
+      }
+   ]
+}

--- a/aries-mobile-tests/features/data/proof_drivers_license_sp_char.json
+++ b/aries-mobile-tests/features/data/proof_drivers_license_sp_char.json
@@ -1,0 +1,29 @@
+{
+      "requested_attributes": {
+         "id_attrs": {
+            "names": [
+                  "name_😀"
+               ],
+            "restrictions": [
+                  {
+                     "schema_name": "drivers_license_😀",
+                     "schema_version": "1.0.0"
+                  }
+            ]
+         }
+      },
+         "requested_predicates": {
+            "age": {
+               "name": "#$%_birth_dateint",
+               "p_type": ">",
+               "p_value": 19420116,
+               "restrictions": [
+                     {
+                        "schema_name": "drivers_license_😀",
+                        "schema_version": "1.0.0"
+                     }
+               ]
+            }
+         },
+   "version": "0.1.0"
+}

--- a/aries-mobile-tests/features/data/schema_drivers_license_😀.json
+++ b/aries-mobile-tests/features/data/schema_drivers_license_😀.json
@@ -1,0 +1,16 @@
+{
+   "schema_name":"drivers_license_😀",
+   "schema_version":"1.0.0",
+   "attributes":[
+      "name_😀",
+      "civic_address_!@#",
+      "city_$%^",
+      "province_&*(",
+      ")_+_country",
+      "~!@_postal_code",
+      "#$%_birth_dateint",
+      "^&*_id",
+      "issue_()_date",
+      "expiry_/0_date"
+   ]
+}

--- a/aries-mobile-tests/sl_ios_config.json
+++ b/aries-mobile-tests/sl_ios_config.json
@@ -4,10 +4,11 @@
             {
                 "platformName": "iOS",
                 "appium:options": {
-                    "app": "storage:filename=BCWallet-1083.ipa",
+                    "app": "storage:filename=BCWallet-1215.ipa",
                     "autoAcceptAlerts": true,
                     "autoDismissAlerts": true,
-                    "automationName": "xcuitest"
+                    "automationName": "xcuitest",
+                    "platformVersion": "16.7|13.7|14.8|15.7.5"
                 },
                 "sauce:options": {
                     "appiumVersion": "2.0.0",


### PR DESCRIPTION
This PR includes the addition of BCW Tests that test extended and special characters. 

It also adjusts the regression runs to the latest minor version of the iOS major versions. This way we don't test iOS 13.6 when iOS 13.8 is the latest. 