### PR TITLE
BCW fix wallet name tets for small devices and enhance performance

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -118,6 +118,7 @@ def step_impl(context):
 
 @given('the Holder has selected to use biometrics to unlock BC Wallet')
 def step_impl(context):
+    context.biometrics_choosen = True
     context.execute_steps('''
         When the User selects to use Biometrics
         Then they land on the Home screen
@@ -235,6 +236,7 @@ def step_access_app_with_pin(context):
 
 @given('the User has choosen not to use biometrics to unlock BC Wallet')
 def step_impl(context):
+    context.biometrics_choosen = False
     context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
     context.execute_steps('''
         Then they land on the Home screen

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -42,9 +42,8 @@ def an_existing_wallet_user(context):
         When they relaunch the app
     ''')
 
-    # create the biometrics page in the context object
-    context.thisBiometricsPage = BiometricsPage(context.driver)
-    if context.thisBiometricsPage.on_this_page():
+    if context.biometrics_choosen == True:
+        context.thisBiometricsPage = BiometricsPage(context.driver)
         context.execute_steps('''
             When authenticates with thier biometrics
         ''')          
@@ -53,6 +52,7 @@ def an_existing_wallet_user(context):
             When they enter thier PIN as "{pin}"
         ''')
 
+    # TODO this step takes a long time, fix it.
     context.execute_steps('''
         Then they have access to the app
     ''')

--- a/aries-mobile-tests/pageobjects/bc_wallet/name_your_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/name_your_wallet.py
@@ -12,6 +12,8 @@ class NameYourWalletPage(BasePage):
 
     # Locators
     on_this_page_text_locator = "Name your wallet"
+    message_locator = (AppiumBy.ACCESSIBILITY_ID, "This is the name people see when connecting with you.")
+    input_title_locator = (AppiumBy.ACCESSIBILITY_ID, "Name your wallet")
     back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
     wallet_name_input_locator = (AppiumBy.ID, "com.ariesbifold:id/NameInput")
     save_locator = (AppiumBy.ID, "com.ariesbifold:id/Save")
@@ -45,6 +47,9 @@ class NameYourWalletPage(BasePage):
         wallet_name_input = self.find_by(self.wallet_name_input_locator)
         wallet_name_input.clear()
         wallet_name_input.send_keys(wallet_name)
+        # If the wallet name is empty the keyboard is probably still open and could be hiding the save button, close the keyboard.
+        if wallet_name == "" and self.current_platform == "iOS":
+            self.find_by(self.message_locator).click() # works on iOS
 
 
 


### PR DESCRIPTION
This PR fixes a wallet naming issue where if the device is smaller and we are testing null values in the wallet name field the iOS keyboard does not close and is over the save button, causing the click save to fail. 

This PR also speeds up the restart of the app to get ready for the test. It no longer checks if the biometrics page is displayed but check a boolean flag that was set when the wallet was setup.