### PR TITLE
BCW remove Skip from onboarding tests

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/credential_offer.feature
+++ b/aries-mobile-tests/features/bc_wallet/credential_offer.feature
@@ -26,7 +26,7 @@ Feature: Offer a Credential
 
    @T002-CredentialOffer @critical @AcceptanceTest @Story_79 @Story_82
    Scenario: Holder accepts the credential offer recieved
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -43,7 +43,7 @@ Feature: Offer a Credential
 
    @T002.1-CredentialOffer @critical @AcceptanceTest @Story_79 @Story_82
    Scenario Outline: Holder accepts the credential offer recieved
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -65,7 +65,7 @@ Feature: Offer a Credential
 
    @T003-CredentialOffer @wip @critical @AcceptanceTest @Story_79
    Scenario: Holder declines the credential offer recieved
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -110,7 +110,7 @@ Feature: Offer a Credential
 
    @T006-CredentialOffer @wip @critical @AcceptanceTest @Story_79 @Story_82
    Scenario: Holder accepts the credential offer recieved with previous credential(s)
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -145,7 +145,7 @@ Feature: Offer a Credential
 
    @T008-CredentialOffer @normal @FunctionalTest @PerformanceTest
    Scenario Outline: Holder multiple credentials and no issuance should talke a long time
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet

--- a/aries-mobile-tests/features/bc_wallet/onboarding.feature
+++ b/aries-mobile-tests/features/bc_wallet/onboarding.feature
@@ -22,20 +22,20 @@ Feature: Onboarding
     And are brought to the Terms and Conditions screen
 
 
-  @T002-Onboarding @AcceptanceTest
-  Scenario Outline: New User skips onboarding screens
-    Given the new user has opened the app for the first time
-    And the user is on the Is this app for you screen
-    And the user selects confirms that the app is for them
-    And they select Continue
-    And the user is on the onboarding <screen>
-    When the user selects Skip
-    Then are brought to the Terms and Conditions screen
+  # @T002-Onboarding @AcceptanceTest @depricated_nov_7_2023
+  # Scenario Outline: New User skips onboarding screens
+  #   Given the new user has opened the app for the first time
+  #   And the user is on the Is this app for you screen
+  #   And the user selects confirms that the app is for them
+  #   And they select Continue
+  #   And the user is on the onboarding <screen>
+  #   When the user selects Skip
+  #   Then are brought to the Terms and Conditions screen
 
-    Examples:
-      | screen                          |
-      | A different smart wallet screen |
-      | Digital credentials screen      |
+  #   Examples:
+  #     | screen                          |
+  #     | A different smart wallet screen |
+  #     | Digital credentials screen      |
 
 
   @T003-Onboarding @AcceptanceTest

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -32,7 +32,7 @@ Feature: Proof
 
    @T002-Proof @critical @AcceptanceTest @Story_29 @SmokeTest
    Scenario: Holder accepts the proof request
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -52,7 +52,7 @@ Feature: Proof
 
    @T002.1-Proof @critical @AcceptanceTest @Story_29
    Scenario Outline: Holder accepts the proof request
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -76,7 +76,7 @@ Feature: Proof
 
    @T002.2-Proof @normal @FunctionalTest @Story_29
    Scenario Outline: Holder accepts the proof request credential has special characters
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -97,7 +97,7 @@ Feature: Proof
 
    @T003-Proof @critical @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a revoked credential where the verifier cares if the credential was revoked
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -119,7 +119,7 @@ Feature: Proof
 
    @T004-Proof @normal @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a non-revoked revokable credential where the verifier cares if the credential was revoked
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -143,7 +143,7 @@ Feature: Proof
 
    @T005-Proof @normal @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a revoked credential where the verifier doesn't care if the credential was revoked
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -168,7 +168,7 @@ Feature: Proof
 
    @T006-Proof @normal @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a non-revoked revokable credential where the verifier doesn't care if the credential was revoked
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -193,7 +193,7 @@ Feature: Proof
    # if a non-revokable credential can be presented then that should take precedent over revokable credentials since it de facto satisfies proof of non-revocation.
    @T007-Proof @normal @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a non-revoked credential and presents a non-revokable credential
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -219,7 +219,7 @@ Feature: Proof
 
    @T008-Proof @critical @AcceptanceTest @Revocation
    Scenario Outline: Holder accepts the proof request of a non-revoked credential and presents a non-revokable credential that has been revoked and reissued
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
@@ -386,7 +386,7 @@ Feature: Proof
 
    @T012.1-Proof @normal @AcceptanceTest @SelfAttestation @Story_239 @wip
    Scenario Outline: Holder accepts the proof request that contains self-attested attributes but the attribute is in an existing credential
-      Given the User has skipped on-boarding
+      Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet

--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -62,7 +62,7 @@ Feature: Secure your Wallet
 
   @T005-Security @AcceptanceTest @ExceptionTest @normal
   Scenario: New User Sets Up PIN but PINs do not match
-    Given the User has skipped on-boarding
+    Given the User has completed on-boarding
     And the User has accepted the Terms and Conditions
     And the User is on the PIN creation screen
     When the User enters the first PIN as "369369"
@@ -78,7 +78,7 @@ Feature: Secure your Wallet
 
   @T006-Security @FunctionalTest @ExceptionTest @normal
   Scenario Outline: New User Sets Up PIN but does not follow conventions
-    Given the User has skipped on-boarding
+    Given the User has completed on-boarding
     And the User has accepted the Terms and Conditions
     And the User is on the PIN creation screen
     When the User enters the first PIN as <pin>

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -140,13 +140,13 @@ def step_impl(context, using_the_app):
         ''')
     elif using_the_app == "PIN Setup":
         context.execute_steps(f'''
-            Given the User has skipped on-boarding
+            Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And the User is on the PIN creation screen
         ''')
     elif using_the_app == "Receiving Credential":
         context.execute_steps(f'''
-            Given the User has skipped on-boarding
+            Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
             And the Holder has selected to use biometrics to unlock BC Wallet
@@ -157,7 +157,7 @@ def step_impl(context, using_the_app):
         ''')
     elif using_the_app == "Presenting Proof":
         context.execute_steps(f'''
-            Given the User has skipped on-boarding
+            Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
             And the Holder has selected to use biometrics to unlock BC Wallet

--- a/aries-mobile-tests/features/steps/bc_wallet/onboarding.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/onboarding.py
@@ -107,9 +107,9 @@ def step_impl(context, screen):
         raise Exception(f"Unexpected screen, {screen}")
 
 
-@when('the user selects Skip')
-def step_impl(context):
-    context.thisTermsAndConditionsPage = context.currentOnboardingPage.select_skip()
+# @when('the user selects Skip')
+# def step_impl(context):
+#     context.thisTermsAndConditionsPage = context.currentOnboardingPage.select_skip()
 
 
 @when('the user selects Back')

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -374,7 +374,7 @@ def step_impl(context):
 @given('the PCTF Member has setup thier Wallet')
 def step_impl(context):
     context.execute_steps(f'''
-            Given the User has skipped on-boarding
+            Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
             And the Holder has selected to use biometrics to unlock BC Wallet
@@ -385,7 +385,7 @@ def step_impl(context):
 @given('the Holder has setup thier Wallet')
 def step_impl(context):
     context.execute_steps(f'''
-            Given the User has skipped on-boarding
+            Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
         ''')

--- a/aries-mobile-tests/features/steps/bc_wallet/terms.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/terms.py
@@ -31,16 +31,16 @@ def step_impl(context):
         ''')
 
 
-@given('the User has skipped on-boarding')
-def step_impl(context):
-    context.execute_steps(f'''
-            Given the new user has opened the app for the first time
-            Given the user is on the Is this app for you screen
-            When the user selects confirms that the app is for them
-            And they select Continue
-            And they are brought to the A different smart wallet screen
-            And the user selects Skip
-        ''')
+# @given('the User has skipped on-boarding')
+# def step_impl(context):
+#     context.execute_steps(f'''
+#             Given the new user has opened the app for the first time
+#             Given the user is on the Is this app for you screen
+#             When the user selects confirms that the app is for them
+#             And they select Continue
+#             And they are brought to the A different smart wallet screen
+#             And the user selects Skip
+#         ''')
 
 @given('the User was on the Terms and Conditions screen')
 @given('the User is on the Terms and Conditions screen')

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -24,7 +24,7 @@ def an_existing_wallet_user(context):
     biometrics = context.table[0]['biometrics']
     
     context.execute_steps(f'''
-        Given the User has skipped on-boarding
+        Given the User has completed on-boarding
         And the User has accepted the Terms and Conditions
         And a PIN has been set up with "{pin}"
     ''')

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboarding_a_different_smart_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboarding_a_different_smart_wallet.py
@@ -10,7 +10,7 @@ class OnboardingADifferentSmartWalletPage(BasePage):
     # Locators
     on_this_page_text_locator = "A different smart wallet"
     on_this_page_locator = (AppiumBy.NAME, "A different smart wallet")
-    skip_locator = (AppiumBy.ID, "com.ariesbifold:id/Skip")
+    #skip_locator = (AppiumBy.ID, "com.ariesbifold:id/Skip")
     next_locator = (AppiumBy.ID, "com.ariesbifold:id/Next")
 
     def on_this_page(self):    
@@ -31,9 +31,9 @@ class OnboardingADifferentSmartWalletPage(BasePage):
         else:
             raise Exception(f"App not on the {type(self)} page")
 
-    def select_skip(self):
-        if self.on_this_page():
-            self.find_by(self.skip_locator).click()
-            return TermsAndConditionsPage(self.driver)
-        else:
-            raise Exception(f"App not on the {type(self)} page")
+    # def select_skip(self):
+    #     if self.on_this_page():
+    #         self.find_by(self.skip_locator).click()
+    #         return TermsAndConditionsPage(self.driver)
+    #     else:
+    #         raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboarding_digital_credentials.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboarding_digital_credentials.py
@@ -10,7 +10,7 @@ class OnboardingDigitalCredentialsPage(BasePage):
     # Locators
     on_this_page_text_locator = "Digital credentials"
     on_this_page_locator = (AppiumBy.NAME, "Digital credentials")
-    skip_locator = (AppiumBy.ID, "com.ariesbifold:id/Skip")
+    #skip_locator = (AppiumBy.ID, "com.ariesbifold:id/Skip")
     back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
     next_locator = (AppiumBy.ID, "com.ariesbifold:id/Next")
 
@@ -40,9 +40,9 @@ class OnboardingDigitalCredentialsPage(BasePage):
         else:
             raise Exception(f"App not on the {type(self)} page")
 
-    def select_skip(self):
-        if self.on_this_page():
-            self.find_by(self.skip_locator).click()
-            return TermsAndConditionsPage(self.driver)
-        else:
-            raise Exception(f"App not on the {type(self)} page")
+    # def select_skip(self):
+    #     if self.on_this_page():
+    #         self.find_by(self.skip_locator).click()
+    #         return TermsAndConditionsPage(self.driver)
+    #     else:
+    #         raise Exception(f"App not on the {type(self)} page")


### PR DESCRIPTION
This PR removes the Onboarding skip functionality and testing from the BC Wallet regression tests. Skip has been removed from BC Wallet app. It is possible that the skip could re-emerge as functionality in BC Wallet so it is being left in the tests but commented out. If there comes a time in the future where we are sure Skip will not return, we will permanently remove the code. 