### PR TITLE
BCW test fixes for testids for wallet naming tests

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/wallet_naming.feature
+++ b/aries-mobile-tests/features/bc_wallet/wallet_naming.feature
@@ -27,7 +27,7 @@ Feature: Wallet Naming
     Examples:
       | user_state |
       | the menu   |
-  #| Scan my QR code |
+      | Scan my QR code |
 
 
   @T002-WalletNaming @AcceptanceTest @Story_1200 @normal @CanRunOnSLVirtualDevice
@@ -48,7 +48,7 @@ Feature: Wallet Naming
     Examples:
       | user_state |
       | the menu   |
-  #| Scan my QR code |
+      | Scan my QR code |
 
   @T002.1-WalletNaming @FunctionalTest @Story_1200 @minor @CanRunOnSLVirtualDevice
   Scenario Outline: Wallet user updates and saves thier wallet name, then changes back to original name
@@ -71,7 +71,7 @@ Feature: Wallet Naming
     Examples:
       | user_state |
       | the menu   |
-  #| Scan my QR code |
+      | Scan my QR code |
 
   @T003-WalletNaming @AcceptanceTest @Story_1148 @normal @wip
   Scenario: New Wallet User updates thier wallet name during onboarding

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -13,6 +13,8 @@ from agent_controller_client import agent_controller_GET, agent_controller_POST,
 # import Page Objects needed
 from pageobjects.bc_wallet.biometrics import BiometricsPage
 from pageobjects.bc_wallet.camera_privacy_policy import CameraPrivacyPolicyPage
+from pageobjects.bc_wallet.scan_my_qr_code import ScanMyQRCodePage
+from pageobjects.bc_wallet.settings import SettingsPage
 
 
 @step('an existing {actor} wallet user')
@@ -149,18 +151,29 @@ def step_impl(context):
 
 @then(u'the name of the wallet is changed everywhere it is presented')
 def step_impl(context):
-    # Get the wallet name locations from the context table
-    wallet_name_locations = context.table[0]['wallet_name_location']
-    # Split the locations into a list
-    wallet_name_locations = wallet_name_locations.split(',')
-    # check each location in the app for the new wallet name
-    for location in wallet_name_locations:
+    for row in context.table:
+        # Get the new wallet name from the context table or use the wallet_name parameter
+        location = row['wallet_name_location']
         if location == 'the menu':
+            if "thisSettingsPage" not in context:
+                context.thisSettingsPage = SettingsPage(context.driver)
+            if context.thisSettingsPage.on_this_page() == False:
+                # we are probably on the Scan my QR code page so go back to the menu
+                context.thisSettingsPage = context.thisScanMyQRCodePage.select_back()
             assert context.thisSettingsPage.on_this_page(), 'The user is not on the settings/menu page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
             #assert context.thisSettingsPage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the settings/menu page.'
             assert temp_get_wallet_name(context.thisSettingsPage) == context.new_wallet_name, 'The wallet name is not correct on the settings/menu page.'
         elif location == 'Scan my QR code':
+            if "thisScanMyQRCodePage" not in context:
+                context.thisScanMyQRCodePage = ScanMyQRCodePage(context.driver) 
+            if context.thisScanMyQRCodePage.on_this_page() == False:
+                # we are probably on the settings page so go back to the Scan my QR code page
+                context.thisScanMyQRCodePage = context.thisSettingsPage.select_scan_my_qr_code()
+                if context.driver.capabilities['platformName'] == 'iOS':
+                    context.thisCameraPrivacyPolicyPage = CameraPrivacyPolicyPage(context.driver)
+                    if context.thisCameraPrivacyPolicyPage.on_this_page():
+                        context.thisCameraPrivacyPolicyPage.select_allow()
             assert context.thisScanMyQRCodePage.on_this_page(), 'The user is not on the Scan my QR code page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
             #assert context.thisScanMyQRCodePage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the Scan my QR code page.'
@@ -170,18 +183,29 @@ def step_impl(context):
 
 @then(u'the name of the wallet is unchanged everywhere it is presented')
 def step_impl(context):
-    # Get the wallet name locations from the context table
-    wallet_name_locations = context.table[0]['wallet_name_location']
-    # Split the locations into a list
-    wallet_name_locations = wallet_name_locations.split(',')
-    # check each location in the app for the new wallet name
-    for location in wallet_name_locations:
+    for row in context.table:
+        # Get the new wallet name from the context table or use the wallet_name parameter
+        location = row['wallet_name_location']
         if location == 'the menu':
+            if hasattr(context, 'thisSettingsPage') == False:
+                context.thisSettingsPage = SettingsPage(context.driver)
+            if context.thisSettingsPage.on_this_page() == False:
+                # we are probably on the Scan my QR code page so go back to the menu
+                context.thisSettingsPage = context.thisScanMyQRCodePage.select_back()
             assert context.thisSettingsPage.on_this_page(), 'The user is not on the settings/menu page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
             #assert context.thisSettingsPage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the settings/menu page.'
             assert temp_get_wallet_name(context.thisSettingsPage) == context.original_wallet_name, 'The wallet name is not correct on the settings/menu page.'
         elif location == 'Scan my QR code':
+            if hasattr(context, 'thisScanMyQRCodePage') == False:
+                context.thisScanMyQRCodePage = ScanMyQRCodePage(context.driver)
+            if context.thisScanMyQRCodePage.on_this_page() == False:
+                # we are probably on the settings page so go back to the Scan my QR code page
+                context.thisScanMyQRCodePage = context.thisSettingsPage.select_scan_my_qr_code()
+                if context.driver.capabilities['platformName'] == 'iOS':
+                    context.thisCameraPrivacyPolicyPage = CameraPrivacyPolicyPage(context.driver)
+                    if context.thisCameraPrivacyPolicyPage.on_this_page():
+                        context.thisCameraPrivacyPolicyPage.select_allow()
             assert context.thisScanMyQRCodePage.on_this_page(), 'The user is not on the Scan my QR code page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
             #assert context.thisScanMyQRCodePage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the Scan my QR code page.'

--- a/aries-mobile-tests/pageobjects/bc_wallet/name_your_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/name_your_wallet.py
@@ -58,6 +58,9 @@ class NameYourWalletPage(BasePage):
         if not self.on_this_page():
             raise Exception(f"App not on the {type(self)} page")
 
+        # sometimes the save button is hidden by the keyboard, so close the keyboard
+        self.find_by(self.message_locator).click()
+
         self.find_by(self.save_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
         return self.calling_page

--- a/aries-mobile-tests/pageobjects/bc_wallet/scan_my_qr_code.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/scan_my_qr_code.py
@@ -16,11 +16,10 @@ class ScanMyQRCodePage(BasePage):
     on_this_page_text_locator = "My QR code"
     #back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
     back_locator = (AppiumBy.ID, "Back")
-    #edit_wallet_name_locator = (AppiumBy.ID, "com.ariesbifold:id/EditWalletName")
-    edit_wallet_name_locator = (AppiumBy.ID, "Edit wallet name")
+    edit_wallet_name_locator = (AppiumBy.ID, "com.ariesbifold:id/EditWalletName")
     scan_qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/Scan QR code")
     my_qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/My QR code")
-    qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/QRCode")
+    qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/QRRenderer")
 
     def on_this_page(self):     
         return super().on_this_page(self.on_this_page_text_locator) 
@@ -41,8 +40,8 @@ class ScanMyQRCodePage(BasePage):
         # Don't check if on this page becasue android (unless you scroll back to the top) can't see the App Settings accessibility ID
         # if self.on_this_page():
         self.find_by(self.back_locator).click()
-        from pageobjects.bc_wallet.home import HomePage
-        return HomePage(self.driver)
+        from pageobjects.bc_wallet.settings import SettingsPage
+        return SettingsPage(self.driver)
         # else:
         #     raise Exception(f"App not on the {type(self)} page")
 


### PR DESCRIPTION
Given some changes that now display the testids for the wallet naming tests, the testids have been changed in the tests. This also allows editing wallet name from the scan my QR code page, so that is now enabled in the tests as well. 