### PR TITLE
updated wallet tests with proper wallet name retreival with testid

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -84,7 +84,7 @@ def the_wallet_user_is_in_state_for_wallet_name_change(context, user_state):
     else:
         context.thisSettingsPage.scroll_to_element(context.thisSettingsPage.contacts_aid_locator[1], direction='up')
     
-
+    context.user_state = user_state
     if user_state == 'the menu':
         # We have to get to the settins/menu page for the scan my qr code anyway so no need to do anything extra here.
         assert context.thisSettingsPage.on_this_page(), 'The user is not on the settings/menu page.'
@@ -106,20 +106,15 @@ def the_wallet_user_is_in_state_for_wallet_name_change(context, user_state):
 @when(u'the user changes thier wallet name')
 def step_change_wallet_name(context, wallet_name=None):
     # Check whether we are on the settings/menu page or the Scan my QR code page.
-    if hasattr(context, 'thisSettingsPage'):
+    if context.user_state == 'the menu':
         # This is commented out until we have a testID on the Wallet Name, issue 1557
-        #context.original_wallet_name = context.thisSettingsPage.get_wallet_name()
         if hasattr(context, 'original_wallet_name') == False:
-            context.original_wallet_name = temp_get_wallet_name(context.thisSettingsPage)
+            context.original_wallet_name = context.thisSettingsPage.get_wallet_name()
         context.thisEditWalletNamePage = context.thisSettingsPage.select_edit_wallet_name()
-    elif hasattr(context, 'thisScanMyQRCodePage'):
-        # This is commented out until we have a testID on the Wallet Name, issue 1557
-        #context.original_wallet_name = context.thisScanMyQRCodePage.get_wallet_name()
+    elif context.user_state == 'Scan my QR code':
         if hasattr(context, 'original_wallet_name') == False:
-            context.original_wallet_name = temp_get_wallet_name(context.thisScanMyQRCodePage)
+            context.original_wallet_name = context.thisScanMyQRCodePage.get_wallet_name()
         context.thisEditWalletNamePage = context.thisScanMyQRCodePage.select_edit_wallet_name()
-    else:
-        assert False, 'The app is not on the "SettingsPage" or "ScanMyQRCodePage".'
     
     # Get the new wallet name from the context table or use the wallet_name parameter
     if wallet_name is None:
@@ -128,12 +123,6 @@ def step_change_wallet_name(context, wallet_name=None):
         context.new_wallet_name = wallet_name
     # Set the new wallet name
     context.thisEditWalletNamePage.enter_wallet_name(context.new_wallet_name)
-
-def temp_get_wallet_name(from_where) -> str:
-    thisEditWalletNamePage = from_where.select_edit_wallet_name()
-    wallet_name = thisEditWalletNamePage.get_wallet_name()
-    thisEditWalletNamePage.select_back()
-    return wallet_name
 
 @when(u'saves the wallet name change')
 def step_impl(context):
@@ -162,8 +151,7 @@ def step_impl(context):
                 context.thisSettingsPage = context.thisScanMyQRCodePage.select_back()
             assert context.thisSettingsPage.on_this_page(), 'The user is not on the settings/menu page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
-            #assert context.thisSettingsPage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the settings/menu page.'
-            assert temp_get_wallet_name(context.thisSettingsPage) == context.new_wallet_name, 'The wallet name is not correct on the settings/menu page.'
+            assert context.thisSettingsPage.get_wallet_name() == context.new_wallet_name, f'The wallet name is not correct on the settings/menu page. {context.thisSettingsPage.get_wallet_name()} should equal {context.new_wallet_name}'
         elif location == 'Scan my QR code':
             if "thisScanMyQRCodePage" not in context:
                 context.thisScanMyQRCodePage = ScanMyQRCodePage(context.driver) 
@@ -176,8 +164,7 @@ def step_impl(context):
                         context.thisCameraPrivacyPolicyPage.select_allow()
             assert context.thisScanMyQRCodePage.on_this_page(), 'The user is not on the Scan my QR code page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
-            #assert context.thisScanMyQRCodePage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the Scan my QR code page.'
-            assert temp_get_wallet_name(context.thisScanMyQRCodePage) == context.new_wallet_name, 'The wallet name is not correct on the Scan my QR code page.'
+            assert context.thisScanMyQRCodePage.get_wallet_name() == context.new_wallet_name, f'The wallet name is not correct on the Scan my QR code page. {context.thisScanMyQRCodePage.get_wallet_name()} should equal {context.new_wallet_name}'
         else:
             assert False, f'"{location}" is not a valid location. Please use "the menu" or "Scan my QR code".'
 
@@ -193,9 +180,7 @@ def step_impl(context):
                 # we are probably on the Scan my QR code page so go back to the menu
                 context.thisSettingsPage = context.thisScanMyQRCodePage.select_back()
             assert context.thisSettingsPage.on_this_page(), 'The user is not on the settings/menu page.'
-            # This is commented out until we have a testID on the Wallet Name, issue 1557
-            #assert context.thisSettingsPage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the settings/menu page.'
-            assert temp_get_wallet_name(context.thisSettingsPage) == context.original_wallet_name, 'The wallet name is not correct on the settings/menu page.'
+            assert context.thisSettingsPage.get_wallet_name() == context.original_wallet_name, f'The wallet name has been changed on the settings/menu page. {context.thisSettingsPage.get_wallet_name()} should equal {context.original_wallet_name}'
         elif location == 'Scan my QR code':
             if hasattr(context, 'thisScanMyQRCodePage') == False:
                 context.thisScanMyQRCodePage = ScanMyQRCodePage(context.driver)
@@ -208,8 +193,7 @@ def step_impl(context):
                         context.thisCameraPrivacyPolicyPage.select_allow()
             assert context.thisScanMyQRCodePage.on_this_page(), 'The user is not on the Scan my QR code page.'
             # This is commented out until we have a testID on the Wallet Name, issue 1557
-            #assert context.thisScanMyQRCodePage.get_wallet_name() == context.new_wallet_name, 'The wallet name is not correct on the Scan my QR code page.'
-            assert temp_get_wallet_name(context.thisScanMyQRCodePage) == context.original_wallet_name, 'The wallet name is not correct on the Scan my QR code page.'
+            assert context.thisScanMyQRCodePage.get_wallet_name() == context.original_wallet_name, f'The wallet name has been changed on the Scan my QR code page. {context.thisScanMyQRCodePage.get_wallet_name()} should equal {context.original_wallet_name}'
         else:
             assert False, f'"{location}" is not a valid location. Please use "the menu" or "Scan my QR code".'
 
@@ -219,7 +203,7 @@ def step_impl(context):
 def step_change_wallet_name_not_following_conventions(context):
 
     if hasattr(context, 'original_wallet_name') == False:
-        context.original_wallet_name = temp_get_wallet_name(context.thisSettingsPage)
+        context.original_wallet_name = context.thisSettingsPage.get_wallet_name()
     context.thisEditWalletNamePage = context.thisSettingsPage.select_edit_wallet_name()
 
 
@@ -253,7 +237,7 @@ def step_Successful_change_of_wallet_name(context):
         context.thisEditWalletNamePage.select_save()
 
         # check if the wallet name is changed
-        assert temp_get_wallet_name(context.thisSettingsPage) == wallet_name, f'The wallet name didnt stick for {wallet_name}.'
+        assert context.thisSettingsPage.get_wallet_name() == wallet_name, f'The wallet name didnt stick for {wallet_name}.'
 
         # Call "the user changes thier wallet name not following conventions" step to get back to get into edit wallet name page
         context.execute_steps('''

--- a/aries-mobile-tests/pageobjects/bc_wallet/name_your_wallet.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/name_your_wallet.py
@@ -72,6 +72,8 @@ class NameYourWalletPage(BasePage):
         if not self.on_this_page():
             raise Exception(f"App not on the {type(self)} page")
 
+        # sometimes the cancel button is hidden by the keyboard, so close the keyboard
+        self.find_by(self.message_locator).click()
         self.find_by(self.cancel_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
         return self.calling_page

--- a/aries-mobile-tests/pageobjects/bc_wallet/scan_my_qr_code.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/scan_my_qr_code.py
@@ -20,6 +20,7 @@ class ScanMyQRCodePage(BasePage):
     scan_qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/Scan QR code")
     my_qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/My QR code")
     qr_code_locator = (AppiumBy.ID, "com.ariesbifold:id/QRRenderer")
+    wallet_name_locator = (AppiumBy.ID, "com.ariesbifold:id/WalletName")
 
     def on_this_page(self):     
         return super().on_this_page(self.on_this_page_text_locator) 
@@ -55,3 +56,5 @@ class ScanMyQRCodePage(BasePage):
     def select_my_qr_code(self):
         self.find_by(self.my_qr_code_locator).click()
 
+    def get_wallet_name(self):
+        return self.find_by(self.wallet_name_locator).text


### PR DESCRIPTION
This update to the BC Wallet tests utilizes the new wallet name testid on the settings and the scan my qr code pages. 