### PR TITLE
fixes to the connectionless oob tests

### DIFF
--- a/aries-mobile-tests/agent_factory/candy_uvp/candy_uvp_issuer_agent_interface.py
+++ b/aries-mobile-tests/agent_factory/candy_uvp/candy_uvp_issuer_agent_interface.py
@@ -3,6 +3,7 @@ Class for actual CANdy Unverified Person Credetial issuer agent
 """
 import base64
 from agent_factory.issuer_agent_interface import IssuerAgentInterface
+from agent_test_utils import add_border_to_qr_code
 from sys import platform
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
@@ -103,7 +104,8 @@ class CANdy_UVP_IssuerAgentInterface(IssuerAgentInterface):
 
         qrcode = self._connect_with_issuer_page.get_qr_code()
         self._issuing_credential_page = IssuingCredentialPage(self.driver)
-        return qrcode
+        #return qrcode
+        return add_border_to_qr_code(qrcode)
 
 
     def restart_issue_credential(self):

--- a/aries-mobile-tests/agent_factory/candy_uvp/pageobjects/connect_with_issuer_page.py
+++ b/aries-mobile-tests/agent_factory/candy_uvp/pageobjects/connect_with_issuer_page.py
@@ -17,13 +17,23 @@ class ConnectWithIssuerPage(WebBasePage):
     def on_this_page(self):     
         return super().on_this_page(self.on_this_page_text_locator) 
 
-    def get_qr_code(self):
-        # if self.on_this_page():
-        qrcode_element = self.find_by(self.qr_code_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED)
-        self.driver.save_screenshot("qrcode.png")
-        #qrcode = Image.open("qrcode.png")
-        qrcode = base64.b64encode(open("qrcode.png", "rb").read())
-        return qrcode.decode('utf-8')
+    # def get_qr_code(self):
+    #     # if self.on_this_page():
+    #     qrcode_element = self.find_by(self.qr_code_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED)
+    #     self.driver.save_screenshot("qrcode.png")
+    #     #qrcode = Image.open("qrcode.png")
+    #     qrcode = base64.b64encode(open("qrcode.png", "rb").read())
+    #     return qrcode.decode('utf-8')
             
-        # else:
-        #     raise Exception(f"App not on the {type(self)} page")
+    #     # else:
+    #     #     raise Exception(f"App not on the {type(self)} page")
+
+    def get_qr_code(self):
+        try:
+            qr_code = self.find_by(self.qr_code_locator, wait_condition=WaitCondition.VISIBILITY_OF_ELEMENT_LOCATED)
+        except Exception as e:
+            if not self.on_this_page():
+                raise Exception(f"App not on the {type(self)} page")
+            else:
+                raise e
+        return qr_code

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -262,7 +262,7 @@ Feature: Proof
          | cred_data_unverified_person |
 
 
-   @T009.1-Proof @critical @AcceptanceTest @Connectionless
+   @T009.1-Proof @critical @AcceptanceTest @Connectionless @oob
    Scenario Outline: Pan Canadian Trust Framework Member aquires access with a connectionless proof request
       Given the PCTF Member has setup thier Wallet
       And the PCTF member has an Unverified Person <credential>
@@ -282,7 +282,7 @@ Feature: Proof
          | cred_data_unverified_person | pcft_connectionless_proof |
 
 
-   @T009.1.debug-Proof @critical @AcceptanceTest @Connectionless @wip
+   @T009.1.debug-Proof @critical @AcceptanceTest @Connectionless @wip @oob
    Scenario Outline: Pan Canadian Trust Framework Member aquires access with a connectionless proof request
       Given the user has a connectionless <proof> request for access to PCTF
          | issuer_agent_type |

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -399,6 +399,7 @@ def step_impl(context, credential):
         Given the Holder receives a credential offer of {credential}
         And they Scan the credential offer QR Code
         And the Connecting completes successfully
+        And the holder opens the credential offer
         Then holder is brought to the credential offer screen
         When they select Accept
         And the holder is informed that their credential is on the way with an indication of loading
@@ -456,6 +457,8 @@ def step_impl(context, proof):
 
     context.device_service_handler.inject_qrcode(qrcode)
 
+    if "thisNavBar" not in context:
+        context.thisNavBar = NavBar(context.driver)
     context.thisConnectingPage = context.thisNavBar.select_scan()
     # This is connectionless and the connecting page doesn't last long. Assume we move quickly to the Proof Request
     context.thisProofRequestPage = ProofRequestPage(context.driver)


### PR DESCRIPTION
This update fixes the BC Wallet tests in the OOB Connectionless proof scenario. Most important thing here is the added step to select the credential on the contact screen which was overlooked when the credential and proof flows were updated. 