### PR TITLE
BCW test handling of in app guides

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -67,7 +67,7 @@ def step_impl(context):
     #assert context.thisInitializationPage.on_this_page()
     context.thisHomePage = context.thisInitializationPage.wait_until_initialized()
     if context.thisHomePage.welcome_to_bc_wallet_modal.is_displayed():
-        #context.thisHomePage.welcome_to_bc_wallet_modal.select_dismiss()
+        context.thisHomePage.welcome_to_bc_wallet_modal.select_dismiss()
         assert True
     else:
         assert context.thisHomePage.on_this_page()

--- a/aries-mobile-tests/pageobjects/bc_wallet/initialization.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/initialization.py
@@ -90,8 +90,8 @@ class OopsSomethingWentWrongModal(BasePage):
     retry_locator = (AppiumBy.ID, "com.ariesbifold:id/Retry")
 
     def on_this_page(self):
-        #return super().on_this_page(self.on_this_page_text_locator)
-        return super().on_this_page(self.error_title_locator)
+        return super().on_this_page(self.on_this_page_text_locator)
+        #return super().on_this_page(self.error_title_locator)
         
     def is_displayed(self):
         return self.on_this_page()


### PR DESCRIPTION
In BC Wallet build 1395 in app guides was turned on by default and shows on the Home screen. This PR updates the tests to dismiss that modal on the home page to continue with the other tests. 