### PR TITLE
Update the Sauce Labs config to use the latest Appium available

### DIFF
--- a/aries-mobile-tests/config.json
+++ b/aries-mobile-tests/config.json
@@ -1,21 +1,20 @@
 {
-  "capabilities": {
-    "firstMatch": [
-      {
-        "platformName": "iOS",
-        "appium:options": {
-          "app": "storage:filename=BCWallet-1083.ipa",
-          "autoAcceptAlerts": true,
-          "autoDismissAlerts": true,
-          "automationName": "xcuitest"
-        },
-        "sauce:options": {
-          "appiumVersion": "2.0.0",
-          "fullReset": true,
-          "sauceLabsImageInjectionEnabled": true,
-          "sessionCreationRetry": "3"
-        }
-      }
-    ]
-  }
+    "capabilities": {
+        "firstMatch": [
+            {
+                "platformName": "Android",
+                "appium:options": {
+                    "app": "storage:filename=BCWallet-1459.aab",
+                    "autoGrantPermissions": true,
+                    "automationName": "UiAutomator2"
+                },
+                "sauce:options": {
+                    "appiumVersion": "latest",
+                    "fullReset": true,
+                    "sauceLabsImageInjectionEnabled": true,
+                    "sessionCreationRetry": "3"
+                }
+            }
+        ]
+    }
 }

--- a/aries-mobile-tests/sl_android_config.json
+++ b/aries-mobile-tests/sl_android_config.json
@@ -4,12 +4,12 @@
             {
                 "platformName": "Android",
                 "appium:options": {
-                    "app": "storage:filename=BCWallet-1083.aab",
+                    "app": "storage:filename=BCWallet-1459.aab",
                     "autoGrantPermissions": true,
                     "automationName": "UiAutomator2"
                 },
                 "sauce:options": {
-                    "appiumVersion": "2.0.0",
+                    "appiumVersion": "latest",
                     "fullReset": true,
                     "sauceLabsImageInjectionEnabled": true,
                     "sessionCreationRetry": "3"

--- a/aries-mobile-tests/sl_ios_config.json
+++ b/aries-mobile-tests/sl_ios_config.json
@@ -4,14 +4,14 @@
             {
                 "platformName": "iOS",
                 "appium:options": {
-                    "app": "storage:filename=BCWallet-1215.ipa",
+                    "app": "storage:filename=BCWallet-1459.ipa",
                     "autoAcceptAlerts": true,
                     "autoDismissAlerts": true,
                     "automationName": "xcuitest",
                     "platformVersion": "16.7|13.7|14.8|15.7.5"
                 },
                 "sauce:options": {
-                    "appiumVersion": "2.0.0",
+                    "appiumVersion": "latest",
                     "sauceLabsImageInjectionEnabled": true,
                     "sessionCreationRetry": "3"
                 }


### PR DESCRIPTION
Update the Sauce Labs config to use the latest Appium available instead of locking to 2.0.0. 
Jan 31, 2024 SL will not be supporting 2.0.0. Setting the configs to latest makes sure we are always using the latest version. The test containers always use the latest Appium Client, so it makes sense to tell SL to use the latest as well. 