### PR TITLE
BCW - Updated Wallet Naming tests to use TestID on Android

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/scan_my_qr_code.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/scan_my_qr_code.py
@@ -27,10 +27,7 @@ class ScanMyQRCodePage(BasePage):
 
 
     def select_edit_wallet_name(self):
-        if self.current_platform == "iOS":
-            self.find_by(self.edit_wallet_name_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
-        else:
-            self.find_by(self.edit_wallet_name_aid_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+        self.find_by(self.edit_wallet_name_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
         # return a new page object for the Edit Wallet Name page
         return NameYourWalletPage(self.driver, calling_page=self)


### PR DESCRIPTION
There was an outstanding issue in BC Wallet in which the testID was not being shown on the Scan My QR Code page for the Edit Wallet Name pencil. This is now fixed and the tests adjusted to find the edit by testID instead of accessibility label. 