### PR TITLE
BCW Updated TestID on is this app for you text

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/onboarding_is_this_app_for_you.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboarding_is_this_app_for_you.py
@@ -12,7 +12,7 @@ class OnboardingIsThisAppForYouPage(BasePage):
     # we could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
     # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
     on_this_page_text_locator = "Is this app for you?"
-    on_this_page_locator = (AppiumBy.NAME, "Is this app for you?") # works on iOS
+    on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/DeveloperCounter")
     confirm_locator = (AppiumBy.ID, "com.ariesbifold:id/IAgree")
     continue_locator = (AppiumBy.ID, "com.ariesbifold:id/Continue")
 
@@ -22,8 +22,6 @@ class OnboardingIsThisAppForYouPage(BasePage):
         timeout = 10
         if "Local" in os.environ['DEVICE_CLOUD']:
             timeout = 100
-        if self.current_platform == "Android":
-            return super().on_this_page(self.on_this_page_text_locator, timeout)  
         return super().on_this_page(self.on_this_page_locator, timeout)   
 
     def get_onboarding_text(self):


### PR DESCRIPTION
The initial onboarding page "Is this app for you?" had a testID added to that text. The page object in the tests now references that tested and uses it for android and iOS execution.