### PR TITLE
Add self hosted to workflow

### DIFF
--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         include:
           - mobile-platform: "-p Android"
-            app-file-name: "-a ${{ needs.check-app-updated.outputs.NEW_APP_NAME }}.aab"
+            app-file-name: "-a BCWallet-1567.aab"
             report-project: "android-multi-device-full"
           - mobile-platform: "-p iOS"
             app-file-name: "-a ${{ needs.check-app-updated.outputs.NEW_APP_NAME }}.ipa"


### PR DESCRIPTION
Due to an issue with the latest BCW build I need to lock in the android run with the last build in order to continue the android regression cancellation issue. 