### PR TITLE
lock on Appium version for touch action

### DIFF
--- a/aries-mobile-tests/requirements.txt
+++ b/aries-mobile-tests/requirements.txt
@@ -4,7 +4,7 @@ SauceClient
 paver==1.3.4
 selenium
 psutil==5.7.2
-Appium-Python-Client
+Appium-Python-Client==3.2.1
 qrcode[pil]~=6.1
 webdriver-manager
 google-api-python-client


### PR DESCRIPTION
Locking in the Appium-Python-Client version to 3.2.1. 4.0.0 was released on March 11th 2024 and removed touch action support which is used for scrolling in BC Wallet. Will have to replace that code and move to 4.0.0 later. 