### PR TITLE
BCW - slight speed increase in creating pin

### DIFF
--- a/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
@@ -42,11 +42,8 @@ class PINSetupPage(BasePage):
             raise Exception(f"App not on the {type(self)} page")
 
     def enter_second_pin(self, pin):
-        if self.on_this_page():
-            self.find_by(self.second_pin_locator).send_keys(pin)
-            return True
-        else:
-            raise Exception(f"App not on the {type(self)} page")
+        self.find_by(self.second_pin_locator).send_keys(pin)
+        return True
 
     def get_second_pin(self):
         if self.on_this_page():


### PR DESCRIPTION
Attempt to speed up the pin creation process. This takes a long time on Android for some reason. May be the known send_keys speed issue on Android. This speed increase is to determine if the Android cancelled jobs are due to elapsed time of a call or the whole test as a whole.