### PR TITLE
BCW Enable Notifications Handling

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -10,6 +10,7 @@ Feature: Connections
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       When the Holder scans the QR code sent by the "issuer"
       And the Holder is taken to the Connecting Screen/modal

--- a/aries-mobile-tests/features/bc_wallet/credential_offer.feature
+++ b/aries-mobile-tests/features/bc_wallet/credential_offer.feature
@@ -13,6 +13,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       When the Holder receives a Non-Revocable credential offer
@@ -29,6 +30,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer
@@ -46,6 +48,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer of <credential>
@@ -68,6 +71,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer
@@ -113,6 +117,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has existing credentials
@@ -130,6 +135,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       When the Holder receives a Non-Revocable credential offer
@@ -148,6 +154,7 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a Non-Revocable credential

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -13,6 +13,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a Non-Revocable credential
@@ -35,6 +36,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a Non-Revocable credential
@@ -55,6 +57,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -79,6 +82,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And the holder has credentials
          | credential                        | revocable | issuer_agent_type | credential_name    |
@@ -100,6 +104,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -122,6 +127,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -146,6 +152,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -171,6 +178,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -196,6 +204,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -222,6 +231,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -389,6 +399,7 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>

--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -57,6 +57,7 @@ Feature: Secure your Wallet
     When the User enters the first PIN as "369369"
     And the User re-enters the PIN as "369369"
     And the User selects Create PIN
+    And the User allows notifications
     And the User selects to use Biometrics
     Then they have access to the app
 

--- a/aries-mobile-tests/features/steps/bc_wallet/give_feedback.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/give_feedback.py
@@ -17,6 +17,7 @@ def step_impl(context):
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
+      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
     ''')
 

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -149,6 +149,7 @@ def step_impl(context, using_the_app):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
+            And the User allows notifications
             And the Holder has selected to use biometrics to unlock BC Wallet
             And a connection has been successfully made
             And the user has a credential offer
@@ -160,6 +161,7 @@ def step_impl(context, using_the_app):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
+            And the User allows notifications
             And the Holder has selected to use biometrics to unlock BC Wallet
             And a connection has been successfully made
             And the holder has a Non-Revocable credential

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -380,6 +380,7 @@ def step_impl(context):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
+            And the User allows notifications
             And the Holder has selected to use biometrics to unlock BC Wallet
         ''')
 
@@ -391,6 +392,7 @@ def step_impl(context):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
+            And the User allows notifications
         ''')
 
 

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -3,7 +3,7 @@
 # 
 # -----------------------------------------------------------
 
-from behave import given, when, then
+from behave import given, when, then, step
 import json
 import os
 from decouple import config
@@ -51,12 +51,31 @@ def step_impl(context, pin):
 @then('the User selects Create PIN')
 @when('the User selects Create PIN')
 def step_impl(context):
-    context.thisOnboardingBiometricsPage = context.thisPINSetupPage.create_pin()
-    context.thisOnboardingBiometricsPage.on_this_page()
+    # context.thisOnboardingBiometricsPage = context.thisPINSetupPage.create_pin()
+    # context.thisOnboardingBiometricsPage.on_this_page()
 
+    context.thisEnableNotificationsPage = context.thisPINSetupPage.create_pin()
+
+
+@step('the User allows notifications')
+def step_enable_notifications(context):
+    assert context.thisEnableNotificationsPage.on_this_page()
+    context.thisOnboardingBiometricsPage = context.thisEnableNotificationsPage.select_continue()
+    # Capabilities are setup to automatically accept system alerts.
+    #context.thisEnableNotificationsSystemModal = context.thisEnableNotificationsPage.select_continue()
+    #assert context.thisEnableNotificationsSystemModal.on_this_page()
+    #context.thisOnboardingBiometricsPage = context.thisEnableNotificationsSystemModal.select_allow()
+
+@step('the User does not allow notifications')
+def step_enable_notifications(context):
+    assert context.thisEnableNotificationsPage.on_this_page()
+    context.thisEnableNotificationsSystemModal = context.thisEnableNotificationsPage.select_continue()
+    assert context.thisEnableNotificationsSystemModal.on_this_page()
+    context.thisOnboardingBiometricsPage = context.thisEnableNotificationsSystemModal.select_dont_allow()
 
 @when('the User selects to use Biometrics')
 def step_impl(context):
+    assert context.thisOnboardingBiometricsPage.on_this_page()
     assert context.thisOnboardingBiometricsPage.select_biometrics()
     context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
     context.device_service_handler.biometrics_authenticate(True)

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -35,6 +35,7 @@ def an_existing_wallet_user(context, actor=None):
         Given the User has completed on-boarding
         And the User has accepted the Terms and Conditions
         And a PIN has been set up with "{pin}"
+        And the User allows notifications
     ''')
     if biometrics == 'on':
         context.execute_steps('''

--- a/aries-mobile-tests/pageobjects/bc_wallet/enable_notifications.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/enable_notifications.py
@@ -1,0 +1,58 @@
+from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import BasePage, WaitCondition
+from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
+
+# These classes can inherit from a BasePage to do common setup and functions
+class EnableNotificationsPage(BasePage):
+    """While Onboarding the user is asked to Enable Notifications this is that screen's page object"""
+
+    # Locators
+    on_this_page_text_locator = "Enable Notifications to get instant alerts"
+    on_this_page_locator = (AppiumBy.NAME, "Enable Notifications to get instant alerts")
+    continue_locator = (AppiumBy.ID, "com.ariesbifold:id/PushNotificationContinue")
+
+    def __init__(self, driver):
+        super().__init__(driver)
+        # Instantiate possible Modals and Alerts for this page
+        self.enable_notifications_system_modal = EnableNotificationsSystemModal(driver)
+
+    def on_this_page(self):   
+        if self.current_platform == "Android":
+            return super().on_this_page(self.on_this_page_text_locator) 
+        return super().on_this_page(self.on_this_page_locator)
+
+    def select_continue(self):
+        self.find_by(self.continue_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+        return OnboardingBiometricsPage(self.driver)
+
+
+class EnableNotificationsSystemModal(BasePage):
+    """Enable Notifications System Modal page object"""
+
+    # Locators
+    on_this_page_text_locator = "Would Like to Send You Notifications"
+    on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/AllowNotifications")
+    allow_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Allow")
+    dont_allow_button_locator = (AppiumBy.ID, "com.ariesbifold:id/DontAllow")
+
+    def on_this_page(self):    
+        return super().on_this_page(self.on_this_page_locator) 
+
+    def select_allow(self):
+        self.find_by(self.not_now_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
+
+    def select_allow(self):
+        self.find_by(self.allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        return OnboardingBiometricsPage(self.driver)
+    
+        # if self.driver.capabilities['platformName'] == 'Android':
+        #     self.select_system_allow_while_using_app()
+        # return True
+
+    def select_dont_allow(self):
+        self.find_by(self.dont_allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        return OnboardingBiometricsPage(self.driver)
+    
+    # def select_system_allow_while_using_app(self):
+    #     self.find_by(self.system_allow_while_using_app, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()

--- a/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
@@ -1,6 +1,6 @@
 from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
+from pageobjects.bc_wallet.enable_notifications import EnableNotificationsPage
 
 
 class PINSetupPage(BasePage):
@@ -56,13 +56,10 @@ class PINSetupPage(BasePage):
             raise Exception(f"App not on the {type(self)} page")
 
     def create_pin(self):
-        if self.on_this_page():
-            self.find_by(self.create_pin_button_tid_locator).click()
+        self.find_by(self.create_pin_button_tid_locator).click()
 
-            # return the wallet initialization page
-            return OnboardingBiometricsPage(self.driver)
-        else:
-            raise Exception(f"App not on the {type(self)} page")
+        # return the wallet enable notifications page
+        return EnableNotificationsPage(self.driver)
 
     def does_pin_match(self, header: str = "PINs do not match"):
         if self.on_this_page():


### PR DESCRIPTION
This PR add the handling of the Enable Notifications screen in BC Wallet when onboarding. This does not add tests for Notifications, it just allows the existing tests to continue through this new page. Notification are enabled by default in the tests because the capabilities are setup to accept system prompts, which is what happens when you select continue on the Enable Notifications screen.