### PR TITLE
move Android BCW test job for investigation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mobile-platform: "-p Android"
-            app-file-name: "-a ${{ needs.check-app-updated.outputs.NEW_APP_NAME }}.aab"
-            report-project: "android-multi-device-full"
           - mobile-platform: "-p iOS"
             app-file-name: "-a ${{ needs.check-app-updated.outputs.NEW_APP_NAME }}.ipa"
             report-project: "ios-multi-device-full"
@@ -58,6 +55,9 @@ jobs:
           - mobile-platform: "-p iOS"
             app-file-name: "-a ${{ needs.check-app-updated.outputs.NEW_APP_NAME }}.ipa"
             report-project: "bc-showcase-ios"
+          - mobile-platform: "-p Android"
+            app-file-name: "-a ${{ needs.check-app-updated.outputs.NEW_APP_NAME }}.aab"
+            report-project: "android-multi-device-full"
     #timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Moving the Android Job to the end and see if job placement has any affect on the cancelling of the Android test run.