### PR TITLE
Refactored ToU and enable notifications in BCW

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -10,7 +10,6 @@ Feature: Connections
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       When the Holder scans the QR code sent by the "issuer"
       And the Holder is taken to the Connecting Screen/modal

--- a/aries-mobile-tests/features/bc_wallet/credential_offer.feature
+++ b/aries-mobile-tests/features/bc_wallet/credential_offer.feature
@@ -13,7 +13,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       When the Holder receives a Non-Revocable credential offer
@@ -30,7 +29,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer
@@ -48,7 +46,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer of <credential>
@@ -71,7 +68,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has a credential offer
@@ -117,7 +113,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the user has existing credentials
@@ -135,7 +130,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       When the Holder receives a Non-Revocable credential offer
@@ -154,7 +148,6 @@ Feature: Offer a Credential
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a Non-Revocable credential

--- a/aries-mobile-tests/features/bc_wallet/proof.feature
+++ b/aries-mobile-tests/features/bc_wallet/proof.feature
@@ -13,7 +13,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a Non-Revocable credential
@@ -36,7 +35,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a Non-Revocable credential
@@ -57,7 +55,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -82,7 +79,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And the holder has credentials
          | credential                        | revocable | issuer_agent_type | credential_name    |
@@ -104,7 +100,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -127,7 +122,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -152,7 +146,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -178,7 +171,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -204,7 +196,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -231,7 +222,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>
@@ -399,7 +389,6 @@ Feature: Proof
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
       And a connection has been successfully made
       And the holder has a credential of <credential>

--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -57,8 +57,8 @@ Feature: Secure your Wallet
     When the User enters the first PIN as "369369"
     And the User re-enters the PIN as "369369"
     And the User selects Create PIN
-    And the User allows notifications
     And the User selects to use Biometrics
+    And the User allows notifications
     Then they have access to the app
 
   @T005-Security @AcceptanceTest @ExceptionTest @normal

--- a/aries-mobile-tests/features/bc_wallet/terms.feature
+++ b/aries-mobile-tests/features/bc_wallet/terms.feature
@@ -10,10 +10,9 @@ Scenario: New User Accepts Terms and Conditions
 Given the User has completed on-boarding
 And the User is on the Terms and Conditions screen
 When the users accepts the Terms and Conditions
-And the user clicks continue
 Then the user transitions to the PIN creation screen
 
-@T002-TandC @AcceptanceTest @normal
+@T002-TandC @AcceptanceTest @normal @depricated @wip
 Scenario: New User Rejects Terms and Conditions
 Given the User has completed on-boarding
 And the User is on the Terms and Conditions screen
@@ -24,8 +23,6 @@ Then the User goes back to the last on-boarding screen they viewed
 Scenario: New User Rejects Terms and Conditions and returns to app to accept
 Given the User has completed on-boarding
 And the User was on the Terms and Conditions screen
-And the user has pressed the back button
-And the user was taken back to the on-boarding screen
 When they have closed the app
 And they relaunch the app
 Then they can accept the Terms and conditions

--- a/aries-mobile-tests/features/steps/bc_wallet/give_feedback.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/give_feedback.py
@@ -17,7 +17,6 @@ def step_impl(context):
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
       And a PIN has been set up with "369369"
-      And the User allows notifications
       And the Holder has selected to use biometrics to unlock BC Wallet
     ''')
 

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -149,7 +149,6 @@ def step_impl(context, using_the_app):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
-            And the User allows notifications
             And the Holder has selected to use biometrics to unlock BC Wallet
             And a connection has been successfully made
             And the user has a credential offer
@@ -161,7 +160,6 @@ def step_impl(context, using_the_app):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
-            And the User allows notifications
             And the Holder has selected to use biometrics to unlock BC Wallet
             And a connection has been successfully made
             And the holder has a Non-Revocable credential

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -380,7 +380,6 @@ def step_impl(context):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
-            And the User allows notifications
             And the Holder has selected to use biometrics to unlock BC Wallet
         ''')
 
@@ -392,7 +391,6 @@ def step_impl(context):
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
             And a PIN has been set up with "369369"
-            And the User allows notifications
         ''')
 
 

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -26,7 +26,6 @@ def step_impl(context):
     context.execute_steps(f'''
         Given the User is on the Terms and Conditions screen
         And the users accepts the Terms and Conditions
-        And the user clicks continue
     ''')
 
 
@@ -51,16 +50,14 @@ def step_impl(context, pin):
 @then('the User selects Create PIN')
 @when('the User selects Create PIN')
 def step_impl(context):
-    # context.thisOnboardingBiometricsPage = context.thisPINSetupPage.create_pin()
-    # context.thisOnboardingBiometricsPage.on_this_page()
-
-    context.thisEnableNotificationsPage = context.thisPINSetupPage.create_pin()
+    context.thisOnboardingBiometricsPage = context.thisPINSetupPage.create_pin()
 
 
 @step('the User allows notifications')
 def step_enable_notifications(context):
     assert context.thisEnableNotificationsPage.on_this_page()
-    context.thisOnboardingBiometricsPage = context.thisEnableNotificationsPage.select_continue()
+    context.thisInitializationPage = context.thisEnableNotificationsPage.select_continue()
+    #context.thisOnboardingBiometricsPage = context.thisEnableNotificationsPage.select_continue()
     # Capabilities are setup to automatically accept system alerts.
     #context.thisEnableNotificationsSystemModal = context.thisEnableNotificationsPage.select_continue()
     #assert context.thisEnableNotificationsSystemModal.on_this_page()
@@ -71,13 +68,14 @@ def step_enable_notifications(context):
     assert context.thisEnableNotificationsPage.on_this_page()
     context.thisEnableNotificationsSystemModal = context.thisEnableNotificationsPage.select_continue()
     assert context.thisEnableNotificationsSystemModal.on_this_page()
-    context.thisOnboardingBiometricsPage = context.thisEnableNotificationsSystemModal.select_dont_allow()
+    context.thisInitializationPage = context.thisEnableNotificationsSystemModal.select_dont_allow()
 
 @when('the User selects to use Biometrics')
 def step_impl(context):
     assert context.thisOnboardingBiometricsPage.on_this_page()
     assert context.thisOnboardingBiometricsPage.select_biometrics()
-    context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
+    #context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
+    context.thisEnableNotificationsPage = context.thisOnboardingBiometricsPage.select_continue()
     context.device_service_handler.biometrics_authenticate(True)
 
 @then('they have access to the app')
@@ -140,8 +138,10 @@ def step_impl(context):
     context.biometrics_choosen = True
     context.execute_steps('''
         When the User selects to use Biometrics
+        And the User allows notifications
         Then they land on the Home screen
     ''')
+    
 
 @when('they have closed the app')
 @given('they have closed the app')
@@ -256,8 +256,9 @@ def step_access_app_with_pin(context):
 @given('the User has choosen not to use biometrics to unlock BC Wallet')
 def step_impl(context):
     context.biometrics_choosen = False
-    context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
+    context.thisEnableNotificationsPage = context.thisOnboardingBiometricsPage.select_continue()
     context.execute_steps('''
+        Given the User allows notifications
         Then they land on the Home screen
     ''')
 

--- a/aries-mobile-tests/features/steps/bc_wallet/terms.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/terms.py
@@ -52,12 +52,8 @@ def step_impl(context):
 @given('the users accepts the Terms and Conditions')
 @when('the users accepts the Terms and Conditions')
 def step_impl(context):
-    context.thisTermsAndConditionsPage.select_accept()
+    context.thisPINSetupPage = context.thisTermsAndConditionsPage.select_accept()
 
-@given('the user clicks continue')
-@when('the user clicks continue')
-def step_impl(context):
-    context.thisPINSetupPage = context.thisTermsAndConditionsPage.select_continue()
 
 
 @given('the User is on the PIN creation screen')
@@ -71,7 +67,6 @@ def step_impl(context):
     context.execute_steps(f'''
             Given the User is on the Terms and Conditions screen
             Given the users accepts the Terms and Conditions
-            When the user clicks continue
             Then the user transitions to the PIN creation screen
         ''')
         

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -35,7 +35,6 @@ def an_existing_wallet_user(context, actor=None):
         Given the User has completed on-boarding
         And the User has accepted the Terms and Conditions
         And a PIN has been set up with "{pin}"
-        And the User allows notifications
     ''')
     if biometrics == 'on':
         context.execute_steps('''

--- a/aries-mobile-tests/pageobjects/bc_wallet/enable_notifications.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/enable_notifications.py
@@ -1,6 +1,6 @@
 from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage, WaitCondition
-from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
+from pageobjects.bc_wallet.initialization import InitializationPage
 
 # These classes can inherit from a BasePage to do common setup and functions
 class EnableNotificationsPage(BasePage):
@@ -24,7 +24,7 @@ class EnableNotificationsPage(BasePage):
     def select_continue(self):
         self.find_by(self.continue_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
 
-        return OnboardingBiometricsPage(self.driver)
+        return InitializationPage(self.driver)
 
 
 class EnableNotificationsSystemModal(BasePage):

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboarding_biometrics.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboarding_biometrics.py
@@ -1,7 +1,7 @@
 import os
 from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.initialization import InitializationPage
+from pageobjects.bc_wallet.enable_notifications import EnableNotificationsPage
 
 class OnboardingBiometricsPage(BasePage):
     """Onboarding Biometrics page object"""
@@ -32,7 +32,8 @@ class OnboardingBiometricsPage(BasePage):
         if self.on_this_page():
             self.find_by(self.continue_button_locator).click()
 
-            # return the wallet initialization page
-            return InitializationPage(self.driver)
+            # return the wallet enable notifications page
+            return EnableNotificationsPage(self.driver)
+            
         else:
             raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/pinsetup.py
@@ -1,6 +1,6 @@
 from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.enable_notifications import EnableNotificationsPage
+from pageobjects.bc_wallet.onboarding_biometrics import OnboardingBiometricsPage
 
 
 class PINSetupPage(BasePage):
@@ -58,8 +58,8 @@ class PINSetupPage(BasePage):
     def create_pin(self):
         self.find_by(self.create_pin_button_tid_locator).click()
 
-        # return the wallet enable notifications page
-        return EnableNotificationsPage(self.driver)
+        # return the wallet biometrics page
+        return OnboardingBiometricsPage(self.driver)
 
     def does_pin_match(self, header: str = "PINs do not match"):
         if self.on_this_page():

--- a/aries-mobile-tests/pageobjects/bc_wallet/termsandconditions.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/termsandconditions.py
@@ -1,6 +1,5 @@
 from appium.webdriver.common.appiumby import AppiumBy
-from pageobjects.basepage import BasePage
-from pageobjects.bc_wallet.secure import SecurePage
+from pageobjects.basepage import BasePage, WaitCondition
 from pageobjects.bc_wallet.pinsetup import PINSetupPage
 from time import sleep
 
@@ -10,16 +9,10 @@ class TermsAndConditionsPage(BasePage):
     """Terms and Conditions page object"""
 
     # Locators
-    # TODO: We could create a locator module that has all the locators. Given a specific app we could load the locators for that app. 
-    # not sure this would be a use case that would be common. Leaving locators with the page objects for now.
     on_this_page_text_locator = "Terms of Use"
     on_this_page_locator = (AppiumBy.NAME, "Terms of Use")
-    terms_and_conditions_accept_aid_locator = "I Agree"
-    terms_and_conditions_accept_locator = (AppiumBy.ID, "com.ariesbifold:id/IAgree")
-    continue_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Continue")
-    continue_button_aid_locator = (AppiumBy.ACCESSIBILITY_ID, "Continue")
-    back_locator = (AppiumBy.ID, "com.ariesbifold:id/Back")
-    back_aid_locator = (AppiumBy.ACCESSIBILITY_ID, "Back")
+    accept_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Accept")
+    accept_button_aid_locator = (AppiumBy.ACCESSIBILITY_ID, "Accept")
 
 
     def on_this_page(self):       
@@ -29,49 +22,16 @@ class TermsAndConditionsPage(BasePage):
 
     def select_accept(self):
         if self.on_this_page():
-            try:
-                self.scroll_to_element(self.back_aid_locator[1])
-            except:
-                # Sometimes it seems that scrolling may try to access the element by accessibility id before it appears
-                # if we get this failure then just sleep and try again. 
-                sleep(5)
-                self.scroll_to_element(self.back_aid_locator[1])
-            self.find_by(self.terms_and_conditions_accept_locator).click()
-            return True
-        else:
-            raise Exception(f"App not on the {type(self)} page")
-
-
-    def select_continue(self):
-        if self.on_this_page():
-            try:
-                self.scroll_to_element(self.back_aid_locator[1])
-            except:
-                # Sometimes it seems that scrolling may try to access the element by accessibility id before it appears
-                # if we get this failure then just sleep and try again. 
-                sleep(5)
-                self.scroll_to_element(self.back_aid_locator[1])
-            self.find_by(self.continue_button_locator).click()
-
-            # Maybe should check if it is checked or let the test call is_accept_checked()? 
-            # return a new page object? The Pin Setup page.
+            # As of 2024-03-21 the app no longer needs to scroll to get to the accept button. BC Wallet Build 1603
+            # Leaving this code here just in case it is needed in the future, and for reference on scrolling.
+            # try:
+            #     self.scroll_to_element(self.back_aid_locator[1])
+            # except:
+            #     # Sometimes it seems that scrolling may try to access the element by accessibility id before it appears
+            #     # if we get this failure then just sleep and try again. 
+            #     sleep(5)
+            #     self.scroll_to_element(self.back_aid_locator[1])
+            self.find_by(self.accept_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
             return PINSetupPage(self.driver)
-        else:
-            raise Exception(f"App not on the {type(self)} page")
-
-
-    def select_back(self):
-        if self.on_this_page():
-            try:
-                self.scroll_to_element(self.back_aid_locator[1])
-            except:
-                # Sometimes it seems that scrolling may try to access the element by accessibility id before it appears
-                # if we get this failure then just sleep and try again. 
-                sleep(5)
-                self.scroll_to_element(self.back_aid_locator[1])
-            self.find_by(self.back_locator).click()
-            # Returning BasePage here since they could of got here by skipping and they would return the the onboarding page
-            # they selected skip on. Tests will have to track what onboarding page they were on in the tests and make sure they are there. 
-            return BasePage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")


### PR DESCRIPTION
Both the Terms of Use Page and the moving of the Enable Notifications to after Biometrics has been refactored in the BC Wallet tests.