### PR TITLE
fix pip install in dockerfile

### DIFF
--- a/aries-mobile-tests/Dockerfile.harness
+++ b/aries-mobile-tests/Dockerfile.harness
@@ -5,8 +5,9 @@ RUN pip install -r requirements.txt
 
 RUN \
     echo "==> Install stuff not in the requirements..."   && \
+    pip install --upgrade pip && \
     pip install --no-cache-dir \
-        aiohttp \
+        aiohttp && \
     pip install --no-cache-dir \
          python-decouple
 


### PR DESCRIPTION
There was a typo in pip install in the docker file for the test harness what was getting through the build for a long while, but recently now it caught and the build fails. 