### PR TITLE
Fix pin page crash in bc wallet automation

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -7,6 +7,7 @@ from behave import given, when, then, step
 import json
 import os
 from decouple import config
+from time import sleep
 
 # Local Imports
 from agent_controller_client import agent_controller_GET, agent_controller_POST, expected_agent_state, setup_already_connected
@@ -155,6 +156,9 @@ def step_impl(context):
 @when('they relaunch the app')
 def step_impl(context):
     context.driver.activate_app(context.driver.capabilities[get_package_or_bundle_id(context)])
+    # There is a crash issue in the automation when entering the pin right after a restart.
+    # wait 5 seconds to stop the crashing or minimize at least.
+    sleep(5)
 
 def get_package_or_bundle_id(context):
     if context.driver.capabilities['platformName'] == 'iOS':

--- a/aries-mobile-tests/sl_ios_config.json
+++ b/aries-mobile-tests/sl_ios_config.json
@@ -8,7 +8,7 @@
                     "autoAcceptAlerts": true,
                     "autoDismissAlerts": true,
                     "automationName": "xcuitest",
-                    "platformVersion": "16.7|13.7|14.8|15.7.5"
+                    "platformVersion": "18|17.7|16.7|13.7|14.8|15.8"
                 },
                 "sauce:options": {
                     "appiumVersion": "latest",


### PR DESCRIPTION
This PR is a fix/workaround for an issue that started with BC Wallet build 1915. The app started to crash when the tests attempted to enter the PIN after the app was closed then restarted. A wait for 5 seconds was added that seems to allow the page to load properly. I cannot duplicate this crash outside of the automation framework. 

This PR also squeezes in some iOS platform version updates to run in the nightly  BC Wallet regression.