### PR TITLE
Pin selenium at 4.25.0

### DIFF
--- a/aries-mobile-tests/requirements.txt
+++ b/aries-mobile-tests/requirements.txt
@@ -2,7 +2,7 @@ behave
 allure-behave
 SauceClient
 paver==1.3.4
-selenium
+selenium==4.25.0
 psutil==5.7.2
 Appium-Python-Client==3.2.1
 qrcode[pil]~=6.1


### PR DESCRIPTION
This PR pins Selenium at 4.25.0. a Change in 4.26.0 has caused issues running the appium python client. 
Following https://github.com/appium/python-client/issues/1053 and will undo the pin once it is fixed. 