### PR TITLE
Added new Why you need a pin page

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -9,6 +9,7 @@ Feature: Connections
    Scenario: Scan QR code to recieve a credential offer
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
+      And the User continues from reviewing Secure your Wallet
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
       When the Holder scans the QR code sent by the "issuer"

--- a/aries-mobile-tests/features/bc_wallet/security.feature
+++ b/aries-mobile-tests/features/bc_wallet/security.feature
@@ -53,6 +53,7 @@ Feature: Secure your Wallet
   Scenario: New User Sets Up PIN
     Given the User has completed on-boarding
     And the User has accepted the Terms and Conditions
+    And the User continues from reviewing Secure your Wallet 
     And the User is on the PIN creation screen
     When the User enters the first PIN as "369369"
     And the User re-enters the PIN as "369369"
@@ -65,6 +66,7 @@ Feature: Secure your Wallet
   Scenario: New User Sets Up PIN but PINs do not match
     Given the User has completed on-boarding
     And the User has accepted the Terms and Conditions
+    And the User continues from reviewing Secure your Wallet 
     And the User is on the PIN creation screen
     When the User enters the first PIN as "369369"
     And the User re-enters the PIN as "369363"
@@ -81,6 +83,7 @@ Feature: Secure your Wallet
   Scenario Outline: New User Sets Up PIN but does not follow conventions
     Given the User has completed on-boarding
     And the User has accepted the Terms and Conditions
+    And the User continues from reviewing Secure your Wallet
     And the User is on the PIN creation screen
     When the User enters the first PIN as <pin>
     And the User re-enters the PIN as <pin>

--- a/aries-mobile-tests/features/steps/bc_wallet/connect.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/connect.py
@@ -32,7 +32,8 @@ def step_impl(context, pin):
     #     Then the User has successfully created a PIN
     # ''')
     context.execute_steps(f'''
-        Given the User is on the PIN creation screen
+        Given the User continues from reviewing Secure your Wallet
+        And the User is on the PIN creation screen
         When the User enters the first PIN as "{pin}"
         And the User re-enters the PIN as "{pin}"
         And the User selects Create PIN

--- a/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/offline_handling.py
@@ -142,6 +142,7 @@ def step_impl(context, using_the_app):
         context.execute_steps(f'''
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
+            And the User continues from reviewing Secure your Wallet
             And the User is on the PIN creation screen
         ''')
     elif using_the_app == "Receiving Credential":

--- a/aries-mobile-tests/features/steps/bc_wallet/proof.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/proof.py
@@ -379,6 +379,7 @@ def step_impl(context):
     context.execute_steps(f'''
             Given the User has completed on-boarding
             And the User has accepted the Terms and Conditions
+            And the User continues from reviewing Secure your Wallet
             And a PIN has been set up with "369369"
             And the Holder has selected to use biometrics to unlock BC Wallet
         ''')

--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -86,7 +86,7 @@ def step_impl(context):
 def step_impl(context):
     # The Home page will not show until the initialization page is done. 
     #assert context.thisInitializationPage.on_this_page()
-    context.thisHomePage = context.thisInitializationPage.wait_until_initialized()
+    #context.thisHomePage = context.thisInitializationPage.wait_until_initialized()
     if context.thisHomePage.welcome_to_bc_wallet_modal.is_displayed():
         context.thisHomePage.welcome_to_bc_wallet_modal.select_dismiss()
         assert True
@@ -176,7 +176,9 @@ def step_impl(context):
         assert context.thisBiometricsPage.on_this_page()
         context.device_service_handler.biometrics_authenticate(True)
         assert context.thisBiometricsPage.on_this_page() == False
-        context.thisInitialzationPage.wait_until_initialized()
+        # Check to make sure we are not already on the home page.
+        if context.thisHomePage.on_this_page() == False:
+            context.thisInitializationPage.wait_until_initialized()
 
 
 @when('fails to authenticate with thier biometrics once')
@@ -188,6 +190,11 @@ def step_impl(context):
     context.device_service_handler.biometrics_authenticate(False)
     #assert context.thisBiometricsPage.on_this_page()
 
+
+@step('the User continues from reviewing Secure your Wallet')
+def step_impl(context):
+    assert context.thisWhyYouNeedAPINPage.on_this_page()
+    context.thisPINSetupPage = context.thisWhyYouNeedAPINPage.select_continue()
 
 @when('they enter thier PIN as "{pin}"')
 def step_impl(context, pin):

--- a/aries-mobile-tests/features/steps/bc_wallet/terms.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/terms.py
@@ -52,7 +52,7 @@ def step_impl(context):
 @given('the users accepts the Terms and Conditions')
 @when('the users accepts the Terms and Conditions')
 def step_impl(context):
-    context.thisPINSetupPage = context.thisTermsAndConditionsPage.select_accept()
+    context.thisWhyYouNeedAPINPage = context.thisTermsAndConditionsPage.select_accept()
 
 
 
@@ -67,6 +67,7 @@ def step_impl(context):
     context.execute_steps(f'''
             Given the User is on the Terms and Conditions screen
             Given the users accepts the Terms and Conditions
+            And the User continues from reviewing Secure your Wallet
             Then the user transitions to the PIN creation screen
         ''')
         

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -34,6 +34,7 @@ def an_existing_wallet_user(context, actor=None):
     context.execute_steps(f'''
         Given the User has completed on-boarding
         And the User has accepted the Terms and Conditions
+        And the User continues from reviewing Secure your Wallet
         And a PIN has been set up with "{pin}"
     ''')
     if biometrics == 'on':

--- a/aries-mobile-tests/pageobjects/bc_wallet/termsandconditions.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/termsandconditions.py
@@ -1,7 +1,7 @@
 from appium.webdriver.common.appiumby import AppiumBy
 from pageobjects.basepage import BasePage, WaitCondition
 from pageobjects.bc_wallet.pinsetup import PINSetupPage
-from time import sleep
+from pageobjects.bc_wallet.why_you_need_a_pin import WhyYouNeedAPINPage
 
 
 # These classes can inherit from a BasePage to do commone setup and functions
@@ -32,6 +32,6 @@ class TermsAndConditionsPage(BasePage):
             #     sleep(5)
             #     self.scroll_to_element(self.back_aid_locator[1])
             self.find_by(self.accept_button_locator, wait_condition=WaitCondition.ELEMENT_TO_BE_CLICKABLE).click()
-            return PINSetupPage(self.driver)
+            return WhyYouNeedAPINPage(self.driver)
         else:
             raise Exception(f"App not on the {type(self)} page")

--- a/aries-mobile-tests/pageobjects/bc_wallet/why_you_need_a_pin.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/why_you_need_a_pin.py
@@ -1,0 +1,22 @@
+from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import BasePage
+from pageobjects.bc_wallet.pinsetup import PINSetupPage
+
+# These classes can inherit from a BasePage to do commone setup and functions
+class WhyYouNeedAPINPage(BasePage):
+    """Secure your wallet Why you need a PIN Info page object"""
+
+    # Locators
+    on_this_page_text_locator = "Why you need a PIN"
+    on_this_page_locator = (AppiumBy.NAME, "Why you need a PIN")
+    continue_locator = (
+        AppiumBy.ID, "com.ariesbifold:id/ContinueCreatePIN")
+
+    def on_this_page(self):     
+        return super().on_this_page(self.on_this_page_locator) 
+
+    def select_continue(self):
+        self.find_by(self.continue_locator).click()
+
+        # return the wallet biometrics page
+        return PINSetupPage(self.driver)


### PR DESCRIPTION
This PR adds the new Why you need a PIN info page to the BC Wallet Tests. 
It also fixes some handling around the initialization page after a restart of the app with biometrics. 