### PR TITLE
Updated bc wallet tests for why_you_need_a_pin on Android

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/terms.feature
+++ b/aries-mobile-tests/features/bc_wallet/terms.feature
@@ -10,6 +10,7 @@ Scenario: New User Accepts Terms and Conditions
 Given the User has completed on-boarding
 And the User is on the Terms and Conditions screen
 When the users accepts the Terms and Conditions
+And the User continues from reviewing Secure your Wallet
 Then the user transitions to the PIN creation screen
 
 @T002-TandC @AcceptanceTest @normal @depricated @wip

--- a/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/wallet_naming.py
@@ -34,7 +34,6 @@ def an_existing_wallet_user(context, actor=None):
     context.execute_steps(f'''
         Given the User has completed on-boarding
         And the User has accepted the Terms and Conditions
-        And the User continues from reviewing Secure your Wallet
         And a PIN has been set up with "{pin}"
     ''')
     if biometrics == 'on':

--- a/aries-mobile-tests/pageobjects/bc_wallet/credential_details.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/credential_details.py
@@ -25,7 +25,7 @@ class CredentialDetailsPage(BasePage):
     def select_back(self):
         if self.on_this_page():
 
-            if self.driver.desired_capabilities['platformName'] == 'Android':
+            if self.current_platform == 'Android':
                 self.find_by(self.back_locator_android).click()
             else:
                 self.find_by(self.back_locator_ios).click()

--- a/aries-mobile-tests/pageobjects/bc_wallet/feedback.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/feedback.py
@@ -26,7 +26,7 @@ class FeedbackPage(BasePage):
 
     def select_exit(self):
         if self.on_this_page():
-            if self.driver.desired_capabilities['platformName'] == 'Android':
+            if self.current_platform == 'Android':
                 self.find_by(self.exit_locator_android).click()
             else:
                 self.find_by(self.exit_locator).click()

--- a/aries-mobile-tests/pageobjects/bc_wallet/why_you_need_a_pin.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/why_you_need_a_pin.py
@@ -12,10 +12,15 @@ class WhyYouNeedAPINPage(BasePage):
     continue_locator = (
         AppiumBy.ID, "com.ariesbifold:id/ContinueCreatePIN")
 
-    def on_this_page(self):     
+    def on_this_page(self):   
+        if self.current_platform == "Android":
+            return super().on_this_page(self.on_this_page_text_locator)  
         return super().on_this_page(self.on_this_page_locator) 
 
     def select_continue(self):
+        # Remove the platform check when BC Wallet bug 2264 is fixed
+        if self.current_platform == "Android":
+            self.scroll_to_bottom()
         self.find_by(self.continue_locator).click()
 
         # return the wallet biometrics page


### PR DESCRIPTION
I missed some items to handle the why_you_need_a_pin page, mostly on Android. Also added new checks for Android Platform in a couple of page objects since desired_capabilities was deprecated. 