### PR TITLE
BC Wallet connection test fix for Why you need a PIN

### DIFF
--- a/aries-mobile-tests/features/bc_wallet/connect.feature
+++ b/aries-mobile-tests/features/bc_wallet/connect.feature
@@ -9,7 +9,6 @@ Feature: Connections
    Scenario: Scan QR code to recieve a credential offer
       Given the User has completed on-boarding
       And the User has accepted the Terms and Conditions
-      And the User continues from reviewing Secure your Wallet
       And a PIN has been set up with "369369"
       And the Holder has selected to use biometrics to unlock BC Wallet
       When the Holder scans the QR code sent by the "issuer"


### PR DESCRIPTION
Removed a superfluous line in a connect test that was checking for Why you need a Pin page twice. 