### PR TITLE
Updated BC Wallet tests for new system biometrics modal

### DIFF
--- a/aries-mobile-tests/features/steps/bc_wallet/security.py
+++ b/aries-mobile-tests/features/steps/bc_wallet/security.py
@@ -75,9 +75,16 @@ def step_enable_notifications(context):
 def step_impl(context):
     assert context.thisOnboardingBiometricsPage.on_this_page()
     assert context.thisOnboardingBiometricsPage.select_biometrics()
-    #context.thisInitializationPage = context.thisOnboardingBiometricsPage.select_continue()
+    
+    # Build 2084+ now has a system modal that needs to be accepted.
+    #assert context.thisOnboardingBiometricsPage.enable_biometrics_system_modal.on_this_page()
+    #context.thisOnboardingBiometricsPage.enable_biometrics_system_modal.select_allow()
+    # Until SauceLabs Case #00155429 is resolved, we need to authenticate with biomtrics. 
+    # 2 Lined above are commented out in the meantime,
+    context.device_service_handler.biometrics_authenticate(True)
+    
     context.thisEnableNotificationsPage = context.thisOnboardingBiometricsPage.select_continue()
-    # Not sure we need this next line since I don't think the app asks to authenticate when you select to use biometrics.
+
     # This is causing the test to fail when using a local android device so make this line conditional
     if "Local" not in os.environ['DEVICE_CLOUD']:
         context.device_service_handler.biometrics_authenticate(True)

--- a/aries-mobile-tests/pageobjects/bc_wallet/onboarding_biometrics.py
+++ b/aries-mobile-tests/pageobjects/bc_wallet/onboarding_biometrics.py
@@ -1,5 +1,6 @@
 import os
 from appium.webdriver.common.appiumby import AppiumBy
+from pageobjects.basepage import BasePage, WaitCondition
 from pageobjects.basepage import BasePage
 from pageobjects.bc_wallet.enable_notifications import EnableNotificationsPage
 
@@ -12,6 +13,10 @@ class OnboardingBiometricsPage(BasePage):
     use_biometrics_toggle_locator = (AppiumBy.ID, "com.ariesbifold:id/ToggleBiometrics")
     continue_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Continue")
 
+    def __init__(self, driver):
+        super().__init__(driver)
+        # Instantiate possible Modals and Alerts for this page
+        self.enable_biometrics_system_modal = EnableBiometricsSystemModal(driver)
 
     def on_this_page(self):   
         timeout = 50
@@ -37,3 +42,28 @@ class OnboardingBiometricsPage(BasePage):
             
         else:
             raise Exception(f"App not on the {type(self)} page")
+
+
+class EnableBiometricsSystemModal(BasePage):
+    """Enable Biometrics System Modal page object"""
+
+    # Locators
+    on_this_page_text_locator = "BC Wallet wants to use your"
+    on_this_page_locator = (AppiumBy.ID, "com.ariesbifold:id/Allow")
+    allow_button_locator = (AppiumBy.ID, "com.ariesbifold:id/Allow")
+    dont_allow_button_locator = (AppiumBy.ID, "com.ariesbifold:id/DontAllow")
+
+    def on_this_page(self):    
+        return super().on_this_page(self.on_this_page_locator) 
+
+    def select_allow(self):
+        self.find_by(self.allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        return OnboardingBiometricsPage(self.driver)
+    
+        # if self.driver.capabilities['platformName'] == 'Android':
+        #     self.select_system_allow_while_using_app()
+        # return True
+
+    def select_dont_allow(self):
+        self.find_by(self.dont_allow_button_locator, wait_condition=WaitCondition.PRESENCE_OF_ELEMENT_LOCATED).click()
+        return OnboardingBiometricsPage(self.driver)


### PR DESCRIPTION
This PR updates the BC Wallet tests for the new system modal the asks to allow biometrics when they toggle biometrics during onboarding. 

The PR is in Draft until SauceLabs fixes or informs how to fix the problem of biometrics authentication triggering instead of the system allow modal when toggling the biometrics on in the wallet.