### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/run-test-harness/action.yml
+++ b/.github/workflows/run-test-harness/action.yml
@@ -66,7 +66,7 @@ runs:
       env:
         NO_TTY: "1"
     - name: archive screenshots
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-screenshots_from_run_action
         path: ./*.png


### PR DESCRIPTION
actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/